### PR TITLE
Backcompat Fixes (re: Woodya discussion)

### DIFF
--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -178,7 +178,10 @@ ZooKeeper.prototype.init = function init(config) {
     self.data_as_buffer = config.data_as_buffer;
     if(this.logger) this.logger("Encoding for data output: %s", self.encoding);
   }
-  return this._native.init.call(this._native, config);
+  this._native.init.call(this._native, config);
+  
+  // The native code returns a ref to itself.  So we should return a ref to the wrapper object
+  return self;  
 }
 
 ZooKeeper.prototype.connect = function connect(options, cb) {


### PR DESCRIPTION
I have 3 fixes:
- Return 'Buffer' objects by default (I was confused on prior behavior)
- The data_as_buffer getter was inverted (oops).
- The init() function was returning the native object.  Fixed it to return the wrapper.

We can also use this pull request to continue our discussion.

I'll add to this PR if we find more issues.
