### PR TITLE
Version number cleanup (re: Woodya discussion)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "zookeeper"
   ,"description": "apache zookeeper client (zookeeper async API >= 3.4.0)"
   ,"notes": "support for Node v0.6.x"
-  ,"version": "3.4.0"
+  ,"version": "3.4.1"
   ,"author": "Yuri Finkelstein <yurif2003@yahoo.com>"
   ,"contributors": [
     "Yuri Finkelstein <yurif2003@yahoo.com>"

--- a/wscript
+++ b/wscript
@@ -4,7 +4,7 @@ import platform
 srcdir = "."
 blddir = "build"
 APPNAME = "zookeeper"
-ZKVERSION = "3.4.0"
+ZKVERSION = "3.4.1"
 OSTYPE = platform.system()
 
 


### PR DESCRIPTION
Here's the version number change we agreed upon
- VERSION constant becomes ZK_VERSION to make it unambiguous
- module version ==> 3.4.0
