### PR TITLE
Fix reconnect issue

### DIFF
--- a/src/node-zk.cpp
+++ b/src/node-zk.cpp
@@ -396,7 +396,7 @@ public:
         Persistent<Function> *callback = cb_unwrap((void*)watcherCtx); \
         assert (callback); \
         Local<Value> lv_zk = (*callback)->GetHiddenValue(HIDDEN_PROP_ZK); \
-        (*callback)->DeleteHiddenValue(HIDDEN_PROP_ZK); \
+        /* (*callback)->DeleteHiddenValue(HIDDEN_PROP_ZK); */ \
         Local<Object> zk_handle = Local<Object>::Cast(lv_zk); \
         ZooKeeper *zk = ObjectWrap::Unwrap<ZooKeeper>(zk_handle); \
         assert(zk);\
@@ -407,7 +407,7 @@ public:
         argv[1] = Integer::New(state); \
         argv[2] = String::New(path); \
         Local<Value> lv_hb = (*callback)->GetHiddenValue(HIDDEN_PROP_HANDBACK); \
-        (*callback)->DeleteHiddenValue(HIDDEN_PROP_HANDBACK); \
+        /* (*callback)->DeleteHiddenValue(HIDDEN_PROP_HANDBACK); */ \
         argv[3] = Local<Value>::New(Undefined ()); \
         if (!lv_hb.IsEmpty()) argv[3] = lv_hb
 


### PR DESCRIPTION
When an connection fails to a server and certain watches are active a failure occurs and kills the node process.
1. Download latest ZooKeeper server
2. Start using the following command
   
   ```
   ./bin/zkServer.sh start
   ```
3. Create test value
   
   ```
   ./bin/zkCli.sh create /test bla
   ```
4. Install latest version of node-zookeeper
   
   ```
   npm install git://github.com/yfinkelstein/node-zookeeper.git
   ```
5. Create the following `test.js` script
   
   ```
   var ZooKeeper = require('zookeeper')
   
   var client = new ZooKeeper({
     connect: 'localhost:2181',
     timeout: 200000,
     debug_level: ZooKeeper.ZOO_LOG_LEVEL_DEBUG,
     host_order_deterministic: false
   })
   
   client.connect(function(err) {
     if (err) throw err
   
     var watch = function() {
       client.aw_get('/test', function() {
         console.log('===============================================================')
         console.log('= watch')
         console.log('===============================================================')
         console.log(arguments)
         watch()
       },
       function() {
         console.log('===============================================================')
         console.log('= data')
         console.log('===============================================================')
         console.log(arguments)
       })
     }
     watch()
   })
   ```
6. Run the node script
   
   ```
   node test.js
   ```
7. Restart ZooKeeper server
   
   ```
   ./bin/zkServer.sh restart
   ```

When I do this I get an `Aborted (core dumped)` error.

From what I can tell when the ZooKeeper client reconnects it fires the events again and because the the zk property and callback references have be removed, an error occurs.

I'm not sure if just not removing the references is the right answer, but it seems to have already been done in the CALLBACK_PROLOG macro.
