### PR TITLE
Bump node.js version number to 0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,5 @@
      ,"test" : "pushd test; ./test; popd"
      ,"doc" : "node-waf doc"
   }
-  ,"engines": { "node": "0.4.x || 0.6.x" }
+  ,"engines": { "node": "0.4.x || 0.6.x || 0.8.x" }
 }


### PR DESCRIPTION
This only bumps the package.json, it does not migrate the native module from ev_io adn ev_timer to uv_poll and uv_timer. As a result you'll get

WARNING: ev_io is deprecated, use uv_poll_t
WARNING: ev_timer is deprecated, use uv_timer_t

on launch.
