### PR TITLE
Node 0.8 timing fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
    "name": "zookeeper"
   ,"description": "apache zookeeper client (zookeeper async API >= 3.4.0)"
-  ,"version": "3.4.3"
+  ,"version": "3.4.4"
   ,"author": "Yuri Finkelstein <yurif2003@yahoo.com>"
   ,"contributors": [
     "Yuri Finkelstein <yurif2003@yahoo.com>"

--- a/src/node-zk.cpp
+++ b/src/node-zk.cpp
@@ -256,6 +256,10 @@ public:
 
     static void zk_timer_cb (EV_P_ ev_timer *w, int revents) {
         LOG_DEBUG(("zk_timer_cb fired"));
+#if NODE_VERSION_AT_LEAST(0, 8, 0)
+        ev_timer_start (EV_DEFAULT_UC_ w);
+#endif
+
         ZooKeeper *zk = static_cast<ZooKeeper*>(w->data);
 #if NODE_VERSION_AT_LEAST(0, 5, 0)
         ev_tstamp now     = ev_now (uv_default_loop()->ev);


### PR DESCRIPTION
Here is a fix for timing issues of node-zookeeper in node 0.8.x.

Node 0.8 deprecated libev and replaced it with libuv. To keep old modules compatible they created an emulated wrapper named [ev-mul.h](https://github.com/joyent/node/blob/master/src/ev-emul.h).
Although that file even includes hacks specific to node-zookeeper (see [__ev_timer_again](https://github.com/joyent/node/blob/master/src/ev-emul.h#L210)), it still has some timing issues. node-zookeeper expects to have a repeating timer but be able to change it's delay on every iteration but that is not possible in libuv, thus I updated the module to use a single run timer but reset it everytime. The change should only affect node 0.8.

There are still warnings shown about deprecated libev_\* calls but fixing those in now just a matter of merging ev_emul.h's logic into node-zk.c which can be done at a later point.

Please consider merging this into upstream and publishing to npmjs.

Thanks
