### PR TITLE
FEATURE : Use apache dynamic urls service instead of static url.

### DIFF
--- a/libzk-build.sh
+++ b/libzk-build.sh
@@ -8,6 +8,8 @@ ZK_VERSION=3.4.6
 ZK=zookeeper-$ZK_VERSION
 ZK_FILE=/$BUILD_TMP/$ZK.tar.gz
 ZK_URL=http://apache.mirrors.tds.net/zookeeper/$ZK/$ZK.tar.gz
+APACHE_DYN_FILE=/$BUILD_TMP/index.html
+APACHE_DYN_URL=http://www.apache.org/dyn/closer.cgi/zookeeper/
 
 if [ "$PLATFORM" != "SunOS" ]; then
     if [ -e "$BUILD/lib/libzookeeper_st.la" ]; then
@@ -16,6 +18,21 @@ if [ "$PLATFORM" != "SunOS" ]; then
     fi
 
     mkdir -p $BUILD_TMP
+
+    if [ -e "$APACHE_DYN_FILE" ] ;then
+        rm -f $APACHE_DYN_FILE
+    fi
+    echo "Get $ZK download url from $APACHE_DYN_URL"
+    curl --silent --keepalive-time 10 --connect-timeout 10 --output $APACHE_DYN_FILE $APACHE_DYN_URL || wget -T 10 $APACHE_DYN_URL -O $APACHE_DYN_FILE
+    if [ $? != 0 ] ; then
+        echo "Can't connect apache.org."
+        exit 1
+    fi
+    ZK_ROOT_URL=$(grep -o "http://mirrors.[a-zA-Z0-9.-\_]*/apache/zookeeper/" $APACHE_DYN_FILE | head -n 1)
+    if [ "x$ZK_ROOT_URL" != "x" ] ; then
+        ZK_URL="$ZK_ROOT_URL/$ZK/$ZK.tar.gz"
+    fi
+
     if [ ! -e "$ZK_FILE" ] ; then
         echo "Downloading $ZK from $ZK_URL"
         curl --silent --output $ZK_FILE $ZK_URL || wget $ZK_URL -O $ZK_FILE


### PR DESCRIPTION
In this pull request, I get download urls of ZooKeeper from `http://www.apache.org/dyn/closer.cgi/zookeeper/` . Using the official web page suggest the fastest url is better than static url. In some country like China, I almost access the `tds.net` cause the network delay or other reason.
And I suggest use blank space instead of tab cause the indent problem.
Set the same version of zk at different platform.
