### PR TITLE
Emit errors from NativeZk.

### DIFF
--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -26,6 +26,10 @@ function ZooKeeper(config) {
     if(ev === 'connect' || ev === 'close') {
       // the event is passing the native object.  need to mangle to return the wrapper
       a1 = self;
+    } else if (ev === 'error') {
+      // the event is passing the native object.  need to mangle to return the error
+      a1 = a2;
+      a2 = undefined;
     }
     self.emit(ev, a1, a2, a3);
   }


### PR DESCRIPTION
This patch emits errors when they occur on the ZooKeeper connection.  For instance the following are example log messages when errors occur:

Connectivity lost for established session:

```
2014-05-02 15:49:02,864:17781:ZOO_ERROR@handle_socket_error_msg@1643: Socket [192.168.0.61:2181] zk retcode=-7, errno=60(Operation timed out): connection to 192.168.0.61:2181 timed out (exceeded timeout by 1ms)
2014-05-02 15:49:02,864:17781:ZOO_ERROR@yield@213: yield:zookeeper_interest returned error: -7 - operation timeout
```

ZooKeeper not listening, not accepting clients:

```
2014-05-02 15:53:27,837:17812:ZOO_ERROR@handle_socket_error_msg@1723: Socket [192.168.0.61:2181] zk retcode=-4, errno=61(Connection refused): failed while receiving a server response
2014-05-02 15:53:27,837:17812:ZOO_ERROR@zk_io_cb@257: yield:zookeeper_process returned error: -4 - connection loss

2014-05-02 15:53:32,838:17812:ZOO_ERROR@handle_socket_error_msg@1699: Socket [192.168.0.61:2181] zk retcode=-4, errno=61(Connection refused): server refused to accept the client
2014-05-02 15:53:32,838:17812:ZOO_ERROR@zk_io_cb@257: yield:zookeeper_process returned error: -4 - connection loss
```

Currently, it is not possible to get notified of these conditions to implement graceful handling.  This patch gives the application visibility into connection errors, so they can be handled.
