### PR TITLE
disable colors for grepping download mirror.

### DIFF
--- a/libzk-build.sh
+++ b/libzk-build.sh
@@ -28,7 +28,7 @@ if [ "$PLATFORM" != "SunOS" ]; then
         echo "Can't connect apache.org."
         exit 1
     fi
-    ZK_ROOT_URL=$(grep -o "http://mirrors.[a-zA-Z0-9.-\_]*/apache/zookeeper/" $APACHE_DYN_FILE | head -n 1)
+    ZK_ROOT_URL=$(grep --color=never -o "http://mirrors.[a-zA-Z0-9.-\_]*/apache/zookeeper/" $APACHE_DYN_FILE | head -n 1)
     if [ "x$ZK_ROOT_URL" != "x" ] ; then
         ZK_URL="$ZK_ROOT_URL/$ZK/$ZK.tar.gz"
     fi


### PR DESCRIPTION
If the user's environment has grep colors on by default then the grepped url will retain those colors, which will then cause the download to fail because the url will include the color code. You can test by executing `export GREP_OPTIONS='--color=always'` before running the build/install.
