### PR TITLE
Make builds run from local dependancy

### DIFF
--- a/libzk-build.sh
+++ b/libzk-build.sh
@@ -3,6 +3,7 @@
 ROOT=`pwd`
 BUILD=$ROOT/build/zk
 BUILD_TMP=$BUILD/tmp
+DEPS=$ROOT/deps
 PLATFORM=`uname`
 ZK_VERSION=3.4.6
 ZK=zookeeper-$ZK_VERSION
@@ -18,29 +19,8 @@ if [ "$PLATFORM" != "SunOS" ]; then
     fi
 
     mkdir -p $BUILD_TMP
-
-    if [ -e "$APACHE_DYN_FILE" ] ;then
-        rm -f $APACHE_DYN_FILE
-    fi
-    echo "Get $ZK download url from $APACHE_DYN_URL"
-    curl --silent --keepalive-time 10 --connect-timeout 10 --output $APACHE_DYN_FILE $APACHE_DYN_URL || wget -T 10 $APACHE_DYN_URL -O $APACHE_DYN_FILE
-    if [ $? != 0 ] ; then
-        echo "Can't connect apache.org."
-        exit 1
-    fi
-    ZK_ROOT_URL=$(grep --color=never -o "http://mirrors.[a-zA-Z0-9.-\_]*/apache/zookeeper/" $APACHE_DYN_FILE | head -n 1)
-    if [ "x$ZK_ROOT_URL" != "x" ] ; then
-        ZK_URL="$ZK_ROOT_URL/$ZK/$ZK.tar.gz"
-    fi
-
-    if [ ! -e "$ZK_FILE" ] ; then
-        echo "Downloading $ZK from $ZK_URL"
-        curl --silent --output $ZK_FILE $ZK_URL || wget $ZK_URL -O $ZK_FILE
-        if [ $? != 0 ] ; then
-            echo "Unable to download zookeeper library"
-            exit 1
-        fi
-    fi
+    
+    cp $DEPS/$ZK.tar.gz $ZK_FILE
 
     cd $BUILD_TMP
 


### PR DESCRIPTION
We get a lot of timeouts and other issues running installs which pull from apache mirrors. Here is a pull request to bundle Zookeeper with the node library. This means that anyone building from npm only relies on npm (or their internal npm mirror).