### PR TITLE
fix build failure on OS X Yosemite

### DIFF
--- a/libzk-build.sh
+++ b/libzk-build.sh
@@ -44,7 +44,24 @@ if [ "$PLATFORM" != "SunOS" ]; then
 
     cd $BUILD_TMP
 
-    tar -zxf $ZK_FILE && \
+    tar -zxf $ZK_FILE
+
+    if [ "$PLATFORM" = "Darwin" ]; then
+        OS_X_VERSION=`sw_vers -productVersion`
+        if [ $OS_X_VERSION = "10.10" ]; then
+            PATCH_URL=https://issues.apache.org/jira/secure/attachment/12673212/ZOOKEEPER-2049.noprefix.trunk.patch
+            PATCH_FILE=/$BUILD_TMP/trunk.patch
+            echo "Downloading yosemite patch"
+            curl --silent --output $PATCH_FILE $PATCH_URL || wget $PATCH_URL -O $PATCH_FILE
+            if [ $? != 0 ] ; then
+                echo "Unable to download yosemite patch"
+                exit 1
+            fi
+            echo "Applying patch"
+            (cd $ZK && patch -p0 < $PATCH_FILE)
+        fi
+    fi
+
     cd $ZK/src/c && \
     ./configure \
         --without-syncapi \


### PR DESCRIPTION
Fixed #99 

There is a function name conflict between Zookeeper and Yosemite, and there is a patch to Zookeeper. So I modified the BASH file to download that patch first and then apply it if workstation is Yosemite.

See https://issues.apache.org/jira/browse/ZOOKEEPER-2049 for more details.
