### PR TITLE
NPM 3.4.6-4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
    "name": "zookeeper"
   ,"description": "apache zookeeper client (zookeeper async API >= 3.4.0)"
-  ,"version": "3.4.6-3"
+  ,"version": "3.4.6-4"
   ,"author": "Yuri Finkelstein <yurif2003@yahoo.com>"
   ,"contributors": [
     "Yuri Finkelstein <yurif2003@yahoo.com>"
@@ -11,6 +11,8 @@
     ,"David Trejo <david.daniel.trejo@gmail.com>"
     ,"Pooya Karimian <pkarimian@sencha.com>"
     ,"Jakub Lekstan <kuebzky@gmail.com>"
+    ,"Matt Lavin <matt.lavin@gmail.com>"
+    ,"Roy Cheng <roy.b.cheng@newegg.com>"
   ]
   ,"repository": {
       "type": "git"


### PR DESCRIPTION
Thank you so much for giving me access to merge fixes into node-zookeeper.  I've merged in two changes that I've been using recently, the libuv assertion fix and the OS X Yosemite compile fix.

I'd like to do a new NPM publish so that the npm version can be used.  I don't have access to publish to npm yet.  This is the change package.json change I was going to make and publish.  Would it be possible to either publish for me, or grant me access to publish?
