### PR TITLE
Support node 0.12

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -11,13 +11,17 @@
             ['OS=="solaris"', {
                 'cflags': ['-Wno-strict-aliasing'],
                 'defines': ['_POSIX_PTHREAD_SEMANTICS'],
-                'include_dirs': ['/opt/local/include/zookeeper'],
-                'ldflags': ['-lzookeeper_st'],
+                'include_dirs': [
+                    '/opt/local/include/zookeeper',
+                    '<!(node -e "require(\'nan\')")'
+                ],
+	            'ldflags': ['-lzookeeper_st'],
             }],
             ['OS=="mac"',{
                 'include_dirs': [
                     '<(module_root_dir)/deps/zookeeper/src/c/include',
-                    '<(module_root_dir)/deps/zookeeper/src/c/generated'
+                    '<(module_root_dir)/deps/zookeeper/src/c/generated',
+                    '<!(node -e "require(\'nan\')")'
                 ],
                 'libraries': ['<(module_root_dir)/deps/zookeeper/src/c/.libs/libzookeeper_st.a'],
                 'xcode_settings': {
@@ -27,7 +31,8 @@
             }],['OS=="linux"',{
                 'include_dirs': [
                     '<(module_root_dir)/deps/zookeeper/src/c/include',
-                    '<(module_root_dir)/deps/zookeeper/src/c/generated'
+                    '<(module_root_dir)/deps/zookeeper/src/c/generated',
+                    '<!(node -e "require(\'nan\')")'
                 ],
                 'libraries': ['<(module_root_dir)/deps/zookeeper/src/c/.libs/libzookeeper_st.a'],
             }]

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   ,"keywords": ["apache", "zookeeper", "client"]
   ,"dependencies": {
     "async": "~0.2.6"
+    ,"nan": "^1.8.4"
     ,"underscore": "*"
   }
   ,"devDependencies": {

--- a/src/buffer_compat.h
+++ b/src/buffer_compat.h
@@ -6,7 +6,7 @@
 #include <node_version.h>
 #include <v8.h>
 
-#if NODE_MINOR_VERSION < 3
+#if NODE_MAJOR_VERSION < 11 && NODE_MINOR_VERSION < 3
 
 char *BufferData(node::Buffer *b) {
     return b->data();
@@ -25,20 +25,25 @@ size_t BufferLength(v8::Local<v8::Object> buf_obj) {
     return buf->length();
 }
 
-#else // NODE_VERSION
+Local<Object> BufferNew(const char* bytes, int length) {
+    Buffer* b = Buffer::New(value_len);
+    memcpy(BufferData(b), value, value_len);
+    return Local<Object>::New(b->handle_);
+}
 
-char *BufferData(node::Buffer *b) {
-    return node::Buffer::Data(b->handle_);
+#else // NODE_VERSION
+#include "nan.h"
+
+Local<Object> BufferNew(const char* bytes, int length) {
+    return NanNewBufferHandle(bytes, length);
 }
-size_t BufferLength(node::Buffer *b) {
-    return node::Buffer::Length(b->handle_);
-}
+
 char *BufferData(v8::Local<v8::Object> buf_obj) {
-    v8::HandleScope scope;
+    NanScope();
     return node::Buffer::Data(buf_obj);
 }
 size_t BufferLength(v8::Local<v8::Object> buf_obj) {
-    v8::HandleScope scope;
+    NanScope();
     return node::Buffer::Length(buf_obj);
 }
 

--- a/src/node-zk.cpp
+++ b/src/node-zk.cpp
@@ -54,19 +54,23 @@ namespace zk {
       return; \
     }
 
-#define DEFINE_STRING(ev,str) static Persistent<String> ev = NODE_PSYMBOL(str)
-DEFINE_STRING (on_closed,            "close");
-DEFINE_STRING (on_connected,         "connect");
-DEFINE_STRING (on_connecting,        "connecting");
-DEFINE_STRING (on_event_created,     "created");
-DEFINE_STRING (on_event_deleted,     "deleted");
-DEFINE_STRING (on_event_changed,     "changed");
-DEFINE_STRING (on_event_child,       "child");
-DEFINE_STRING (on_event_notwatching, "notwatching");
+#define DECLARE_STRING(ev) static Persistent<String> ev; 
+#define INITIALIZE_STRING(ev, str) NanAssignPersistent(ev, NanNew<String>(str)); 
 
-#define DEFINE_SYMBOL(ev)   DEFINE_STRING(ev, #ev)
-DEFINE_SYMBOL (HIDDEN_PROP_ZK);
-DEFINE_SYMBOL (HIDDEN_PROP_HANDBACK);
+DECLARE_STRING (on_closed);
+DECLARE_STRING (on_connected);
+DECLARE_STRING (on_connecting);
+DECLARE_STRING (on_event_created);
+DECLARE_STRING (on_event_deleted);
+DECLARE_STRING (on_event_changed);
+DECLARE_STRING (on_event_child);
+DECLARE_STRING (on_event_notwatching);
+
+#define DECLARE_SYMBOL(ev)   DECLARE_STRING(ev)
+#define INITIALIZE_SYMBOL(ev) INITIALIZE_STRING(ev, #ev)
+  
+DECLARE_SYMBOL (HIDDEN_PROP_ZK);
+DECLARE_SYMBOL (HIDDEN_PROP_HANDBACK);
 
 #define ZOOKEEPER_PASSWORD_BYTE_COUNT 16
 
@@ -79,9 +83,10 @@ struct completion_data {
 class ZooKeeper: public ObjectWrap {
 public:
     static void Initialize (v8::Handle<v8::Object> target) {
-        Local<FunctionTemplate> constructor_template = FunctionTemplate::New(New);
-        constructor_template->SetClassName(String::NewSymbol("ZooKeeper"));
         NanScope();
+
+        Local<FunctionTemplate> constructor_template = NanNew<FunctionTemplate>(New);
+        constructor_template->SetClassName(NanNew("ZooKeeper"));
         constructor_template->InstanceTemplate()->SetInternalFieldCount(1);
 
         NODE_SET_PROTOTYPE_METHOD(constructor_template, "init", Init);
@@ -118,10 +123,10 @@ public:
 
         //extern ZOOAPI struct ACL_vector ZOO_OPEN_ACL_UNSAFE;
         Local<Object> acl_open = Object::New();
-        acl_open->Set(String::NewSymbol("perms"), Integer::New(ZOO_PERM_ALL), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
-        acl_open->Set(String::NewSymbol("scheme"), String::NewSymbol("world"), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
-        acl_open->Set(String::NewSymbol("auth"), String::NewSymbol("anyone"), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
-        constructor_template->Set(String::NewSymbol("ZOO_OPEN_ACL_UNSAFE"), acl_open, static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+        acl_open->Set(NanNew("perms"), Integer::New(ZOO_PERM_ALL), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+        acl_open->Set(NanNew("scheme"), NanNew("world"), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+        acl_open->Set(NanNew("auth"), NanNew("anyone"), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+        constructor_template->Set(NanNew("ZOO_OPEN_ACL_UNSAFE"), acl_open, static_cast<PropertyAttribute>(ReadOnly | DontDelete));
 
         //extern ZOOAPI struct ACL_vector ZOO_READ_ACL_UNSAFE;
         Local<Object> acl_read = Object::New();
@@ -983,6 +988,18 @@ private:
 } // namespace "zk"
 
 extern "C" void init(Handle<Object> target) {
+  INITIALIZE_STRING (zk::on_closed,            "close");
+  INITIALIZE_STRING (zk::on_connected,         "connect");
+  INITIALIZE_STRING (zk::on_connecting,        "connecting");
+  INITIALIZE_STRING (zk::on_event_created,     "created");
+  INITIALIZE_STRING (zk::on_event_deleted,     "deleted");
+  INITIALIZE_STRING (zk::on_event_changed,     "changed");
+  INITIALIZE_STRING (zk::on_event_child,       "child");
+  INITIALIZE_STRING (zk::on_event_notwatching, "notwatching");
+
+  INITIALIZE_SYMBOL (zk::HIDDEN_PROP_ZK);
+  INITIALIZE_SYMBOL (zk::HIDDEN_PROP_HANDBACK);
+
   zk::ZooKeeper::Initialize(target);
 }
 

--- a/src/node-zk.cpp
+++ b/src/node-zk.cpp
@@ -107,20 +107,6 @@ public:
         NODE_SET_PROTOTYPE_METHOD(constructor_template, "a_set_acl", ASetAcl);
         NODE_SET_PROTOTYPE_METHOD(constructor_template, "add_auth", AddAuth);
 
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_CREATED_EVENT);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_DELETED_EVENT);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_CHANGED_EVENT);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_CHILD_EVENT);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_SESSION_EVENT);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_NOTWATCHING_EVENT);
-
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_PERM_READ);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_PERM_WRITE);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_PERM_CREATE);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_PERM_DELETE);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_PERM_ADMIN);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_PERM_ALL);
-
         //extern ZOOAPI struct ACL_vector ZOO_OPEN_ACL_UNSAFE;
         Local<Object> acl_open = Object::New();
         acl_open->Set(NanNew("perms"), Integer::New(ZOO_PERM_ALL), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
@@ -142,73 +128,6 @@ public:
         acl_creator->Set(String::NewSymbol("auth"), String::NewSymbol(""), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
         constructor_template->Set(String::NewSymbol("ZOO_CREATOR_ALL_ACL"), acl_creator, static_cast<PropertyAttribute>(ReadOnly | DontDelete));
 
-        NODE_DEFINE_CONSTANT(constructor_template, ZOOKEEPER_WRITE);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOOKEEPER_READ);
-
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_EPHEMERAL);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_SEQUENCE);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_EXPIRED_SESSION_STATE);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_AUTH_FAILED_STATE);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_CONNECTING_STATE);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_ASSOCIATING_STATE);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_CONNECTED_STATE);
-
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_CREATED_EVENT);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_DELETED_EVENT);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_CHANGED_EVENT);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_CHILD_EVENT);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_SESSION_EVENT);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_NOTWATCHING_EVENT);
-
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_LOG_LEVEL_ERROR);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_LOG_LEVEL_WARN);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_LOG_LEVEL_INFO);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_LOG_LEVEL_DEBUG);
-
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_EXPIRED_SESSION_STATE);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_AUTH_FAILED_STATE);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_CONNECTING_STATE);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_ASSOCIATING_STATE);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOO_CONNECTED_STATE);
-
-
-        NODE_DEFINE_CONSTANT(constructor_template, ZOK);
-
-        /** System and server-side errors.
-         * This is never thrown by the server, it shouldn't be used other than
-         * to indicate a range. Specifically error codes greater than this
-         * value, but lesser than {@link #ZAPIERROR}, are system errors. */
-        NODE_DEFINE_CONSTANT(constructor_template, ZSYSTEMERROR);
-        NODE_DEFINE_CONSTANT(constructor_template, ZRUNTIMEINCONSISTENCY);
-        NODE_DEFINE_CONSTANT(constructor_template, ZDATAINCONSISTENCY);
-        NODE_DEFINE_CONSTANT(constructor_template, ZCONNECTIONLOSS);
-        NODE_DEFINE_CONSTANT(constructor_template, ZMARSHALLINGERROR);
-        NODE_DEFINE_CONSTANT(constructor_template, ZUNIMPLEMENTED);
-        NODE_DEFINE_CONSTANT(constructor_template, ZOPERATIONTIMEOUT);
-        NODE_DEFINE_CONSTANT(constructor_template, ZBADARGUMENTS);
-        NODE_DEFINE_CONSTANT(constructor_template, ZINVALIDSTATE);
-
-        /** API errors.
-         * This is never thrown by the server, it shouldn't be used other than
-         * to indicate a range. Specifically error codes greater than this
-         * value are API errors (while values less than this indicate a
-         * {@link #ZSYSTEMERROR}).
-         */
-        NODE_DEFINE_CONSTANT(constructor_template, ZAPIERROR);
-        NODE_DEFINE_CONSTANT(constructor_template, ZNONODE);
-        NODE_DEFINE_CONSTANT(constructor_template, ZNOAUTH);
-        NODE_DEFINE_CONSTANT(constructor_template, ZBADVERSION);
-        NODE_DEFINE_CONSTANT(constructor_template, ZNOCHILDRENFOREPHEMERALS);
-        NODE_DEFINE_CONSTANT(constructor_template, ZNODEEXISTS);
-        NODE_DEFINE_CONSTANT(constructor_template, ZNOTEMPTY);
-        NODE_DEFINE_CONSTANT(constructor_template, ZSESSIONEXPIRED);
-        NODE_DEFINE_CONSTANT(constructor_template, ZINVALIDCALLBACK);
-        NODE_DEFINE_CONSTANT(constructor_template, ZINVALIDACL);
-        NODE_DEFINE_CONSTANT(constructor_template, ZAUTHFAILED);
-        NODE_DEFINE_CONSTANT(constructor_template, ZCLOSING);
-        NODE_DEFINE_CONSTANT(constructor_template, ZNOTHING);
-        NODE_DEFINE_CONSTANT(constructor_template, ZSESSIONMOVED);
-
         //what's the advantage of using constructor_template->PrototypeTemplate()->SetAccessor ?
         constructor_template->InstanceTemplate()->SetAccessor(String::NewSymbol("state"), StatePropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
         constructor_template->InstanceTemplate()->SetAccessor(String::NewSymbol("client_id"), ClientidPropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
@@ -216,7 +135,91 @@ public:
         constructor_template->InstanceTemplate()->SetAccessor(String::NewSymbol("timeout"), SessionTimeoutPropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
         constructor_template->InstanceTemplate()->SetAccessor(String::NewSymbol("is_unrecoverable"), IsUnrecoverablePropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
 
-        target->Set(String::NewSymbol("ZooKeeper"), constructor_template->GetFunction());
+        Local<Function> constructor = constructor_template->GetFunction();
+
+        NODE_DEFINE_CONSTANT(constructor, ZOO_CREATED_EVENT);
+        NODE_DEFINE_CONSTANT(constructor, ZOO_DELETED_EVENT);
+        NODE_DEFINE_CONSTANT(constructor, ZOO_CHANGED_EVENT);
+        NODE_DEFINE_CONSTANT(constructor, ZOO_CHILD_EVENT);
+        NODE_DEFINE_CONSTANT(constructor, ZOO_SESSION_EVENT);
+        NODE_DEFINE_CONSTANT(constructor, ZOO_NOTWATCHING_EVENT);
+
+        NODE_DEFINE_CONSTANT(constructor, ZOO_PERM_READ);
+        NODE_DEFINE_CONSTANT(constructor, ZOO_PERM_WRITE);
+        NODE_DEFINE_CONSTANT(constructor, ZOO_PERM_CREATE);
+        NODE_DEFINE_CONSTANT(constructor, ZOO_PERM_DELETE);
+        NODE_DEFINE_CONSTANT(constructor, ZOO_PERM_ADMIN);
+        NODE_DEFINE_CONSTANT(constructor, ZOO_PERM_ALL);
+
+        NODE_DEFINE_CONSTANT(constructor, ZOOKEEPER_WRITE);
+        NODE_DEFINE_CONSTANT(constructor, ZOOKEEPER_READ);
+
+        NODE_DEFINE_CONSTANT(constructor, ZOO_EPHEMERAL);
+        NODE_DEFINE_CONSTANT(constructor, ZOO_SEQUENCE);
+        NODE_DEFINE_CONSTANT(constructor, ZOO_EXPIRED_SESSION_STATE);
+        NODE_DEFINE_CONSTANT(constructor, ZOO_AUTH_FAILED_STATE);
+        NODE_DEFINE_CONSTANT(constructor, ZOO_CONNECTING_STATE);
+        NODE_DEFINE_CONSTANT(constructor, ZOO_ASSOCIATING_STATE);
+        NODE_DEFINE_CONSTANT(constructor, ZOO_CONNECTED_STATE);
+
+        NODE_DEFINE_CONSTANT(constructor, ZOO_CREATED_EVENT);
+        NODE_DEFINE_CONSTANT(constructor, ZOO_DELETED_EVENT);
+        NODE_DEFINE_CONSTANT(constructor, ZOO_CHANGED_EVENT);
+        NODE_DEFINE_CONSTANT(constructor, ZOO_CHILD_EVENT);
+        NODE_DEFINE_CONSTANT(constructor, ZOO_SESSION_EVENT);
+        NODE_DEFINE_CONSTANT(constructor, ZOO_NOTWATCHING_EVENT);
+
+        NODE_DEFINE_CONSTANT(constructor, ZOO_LOG_LEVEL_ERROR);
+        NODE_DEFINE_CONSTANT(constructor, ZOO_LOG_LEVEL_WARN);
+        NODE_DEFINE_CONSTANT(constructor, ZOO_LOG_LEVEL_INFO);
+        NODE_DEFINE_CONSTANT(constructor, ZOO_LOG_LEVEL_DEBUG);
+
+        NODE_DEFINE_CONSTANT(constructor, ZOO_EXPIRED_SESSION_STATE);
+        NODE_DEFINE_CONSTANT(constructor, ZOO_AUTH_FAILED_STATE);
+        NODE_DEFINE_CONSTANT(constructor, ZOO_CONNECTING_STATE);
+        NODE_DEFINE_CONSTANT(constructor, ZOO_ASSOCIATING_STATE);
+        NODE_DEFINE_CONSTANT(constructor, ZOO_CONNECTED_STATE);
+
+
+        NODE_DEFINE_CONSTANT(constructor, ZOK);
+
+        /** System and server-side errors.
+         * This is never thrown by the server, it shouldn't be used other than
+         * to indicate a range. Specifically error codes greater than this
+         * value, but lesser than {@link #ZAPIERROR}, are system errors. */
+        NODE_DEFINE_CONSTANT(constructor, ZSYSTEMERROR);
+        NODE_DEFINE_CONSTANT(constructor, ZRUNTIMEINCONSISTENCY);
+        NODE_DEFINE_CONSTANT(constructor, ZDATAINCONSISTENCY);
+        NODE_DEFINE_CONSTANT(constructor, ZCONNECTIONLOSS);
+        NODE_DEFINE_CONSTANT(constructor, ZMARSHALLINGERROR);
+        NODE_DEFINE_CONSTANT(constructor, ZUNIMPLEMENTED);
+        NODE_DEFINE_CONSTANT(constructor, ZOPERATIONTIMEOUT);
+        NODE_DEFINE_CONSTANT(constructor, ZBADARGUMENTS);
+        NODE_DEFINE_CONSTANT(constructor, ZINVALIDSTATE);
+
+        /** API errors.
+         * This is never thrown by the server, it shouldn't be used other than
+         * to indicate a range. Specifically error codes greater than this
+         * value are API errors (while values less than this indicate a
+         * {@link #ZSYSTEMERROR}).
+         */
+        NODE_DEFINE_CONSTANT(constructor, ZAPIERROR);
+        NODE_DEFINE_CONSTANT(constructor, ZNONODE);
+        NODE_DEFINE_CONSTANT(constructor, ZNOAUTH);
+        NODE_DEFINE_CONSTANT(constructor, ZBADVERSION);
+        NODE_DEFINE_CONSTANT(constructor, ZNOCHILDRENFOREPHEMERALS);
+        NODE_DEFINE_CONSTANT(constructor, ZNODEEXISTS);
+        NODE_DEFINE_CONSTANT(constructor, ZNOTEMPTY);
+        NODE_DEFINE_CONSTANT(constructor, ZSESSIONEXPIRED);
+        NODE_DEFINE_CONSTANT(constructor, ZINVALIDCALLBACK);
+        NODE_DEFINE_CONSTANT(constructor, ZINVALIDACL);
+        NODE_DEFINE_CONSTANT(constructor, ZAUTHFAILED);
+        NODE_DEFINE_CONSTANT(constructor, ZCLOSING);
+        NODE_DEFINE_CONSTANT(constructor, ZNOTHING);
+        NODE_DEFINE_CONSTANT(constructor, ZSESSIONMOVED);
+
+
+        target->Set(String::NewSymbol("ZooKeeper"), constructor);
     }
 
     static NAN_METHOD(New) {

--- a/src/node-zk.cpp
+++ b/src/node-zk.cpp
@@ -979,7 +979,7 @@ public:
     }
 
 
-    ZooKeeper () : zhandle(0), clientIdFile(0), fd(-1) {
+    ZooKeeper () : zhandle(0), fd(-1) {
         ZERO_MEM (myid);
         ZERO_MEM (zk_io);
         ZERO_MEM (zk_timer);
@@ -988,7 +988,6 @@ public:
 private:
     zhandle_t *zhandle;
     clientid_t myid;
-    const char *clientIdFile;
     uv_poll_t zk_io;
     uv_timer_t zk_timer;
     int fd;

--- a/src/node-zk.cpp
+++ b/src/node-zk.cpp
@@ -46,11 +46,11 @@ namespace zk {
 #define _LLP_CAST_ (long long *)
 
 #define THROW_IF_NOT(condition, text) if (!(condition)) { \
-      return ThrowException(Exception::Error (NanNew<String>(text))); \
+      return NanThrowError(text); \
     }
 
 #define THROW_IF_NOT_R(condition, text) if (!(condition)) { \
-      ThrowException(Exception::Error (NanNew<String>(text))); \
+      NanThrowError(text); \
       return; \
     }
 

--- a/src/node-zk.cpp
+++ b/src/node-zk.cpp
@@ -219,7 +219,7 @@ public:
         target->Set(String::NewSymbol("ZooKeeper"), constructor_template->GetFunction());
     }
 
-    static Handle<Value> New (const Arguments& args) {
+    static NAN_METHOD(New) {
         NanScope();
         ZooKeeper *zk = new ZooKeeper();
 
@@ -322,7 +322,8 @@ public:
         yield();
         return true;
     }
-    static Handle<Value> Init (const Arguments& args) {
+
+    static NAN_METHOD(Init) {
         NanScope();
 
         THROW_IF_NOT(args.Length() >= 1, "Must pass ZK init object");
@@ -568,7 +569,7 @@ public:
         CALLBACK_EPILOG();
     }
 
-    static Handle<Value> ACreate (const Arguments& args) {
+    static NAN_METHOD(ACreate) {
         A_METHOD_PROLOG(4);
 
         String::Utf8Value _path (args[0]->ToString());
@@ -599,7 +600,7 @@ public:
         free(d);
     }
 
-    static Handle<Value> ADelete (const Arguments& args) {
+    static NAN_METHOD(ADelete) {
         A_METHOD_PROLOG(3);
         String::Utf8Value _path (args[0]->ToString());
         uint32_t version = args[1]->ToUint32()->Uint32Value();
@@ -639,7 +640,7 @@ public:
         CALLBACK_EPILOG();
     }
 
-    static Handle<Value> AExists (const Arguments& args) {
+    static NAN_METHOD(AExists) {
         A_METHOD_PROLOG(3);
 
         String::Utf8Value _path (args[0]->ToString());
@@ -648,7 +649,7 @@ public:
         METHOD_EPILOG(zoo_aexists(zk->zhandle, *_path, watch, &stat_completion, cb));
     }
 
-    static Handle<Value> AWExists (const Arguments& args) {
+    static NAN_METHOD(AWExists) {
         AW_METHOD_PROLOG(3);
         String::Utf8Value _path (args[0]->ToString());
         METHOD_EPILOG(zoo_awexists(zk->zhandle, *_path, &watcher_fn, cbw, &stat_completion, cb));
@@ -670,7 +671,7 @@ public:
         CALLBACK_EPILOG();
     }
 
-    static Handle<Value> Delete (const Arguments& args) {
+    static NAN_METHOD(Delete) {
         NanScope();
 
         ZooKeeper *zk = ObjectWrap::Unwrap<ZooKeeper>(args.This());   
@@ -682,7 +683,7 @@ public:
         NanReturnValue(Int32::New(ret));
     }
 
-    static Handle<Value> AGet (const Arguments& args) {
+    static NAN_METHOD(AGet) {
         A_METHOD_PROLOG(3);
 
         String::Utf8Value _path (args[0]->ToString());
@@ -696,7 +697,7 @@ public:
         WATCHER_CALLBACK_EPILOG();
     }
 
-    static Handle<Value> AWGet (const Arguments& args) {
+    static NAN_METHOD(AWGet) {
         AW_METHOD_PROLOG(3);
 
         String::Utf8Value _path (args[0]->ToString());
@@ -704,7 +705,7 @@ public:
         METHOD_EPILOG(zoo_awget(zk->zhandle, *_path, &watcher_fn, cbw, &data_completion, cb));
     }
 
-    static Handle<Value> ASet (const Arguments& args) {
+    static NAN_METHOD(ASet) {
         A_METHOD_PROLOG(4);
 
         String::Utf8Value _path (args[0]->ToString());
@@ -737,7 +738,7 @@ public:
         CALLBACK_EPILOG();
     }
 
-    static Handle<Value> AGetChildren (const Arguments& args) {
+    static NAN_METHOD(AGetChildren) {
         A_METHOD_PROLOG(3);
 
         String::Utf8Value _path (args[0]->ToString());
@@ -746,7 +747,7 @@ public:
         METHOD_EPILOG(zoo_aget_children(zk->zhandle, *_path, watch, &strings_completion, cb));
     }
 
-    static Handle<Value> AWGetChildren (const Arguments& args) {
+    static NAN_METHOD(AWGetChildren) {
         AW_METHOD_PROLOG(3);
 
         String::Utf8Value _path (args[0]->ToString());
@@ -774,7 +775,7 @@ public:
         CALLBACK_EPILOG();
     }
 
-    static Handle<Value> AGetChildren2 (const Arguments& args) {
+    static NAN_METHOD(AGetChildren2) {
         A_METHOD_PROLOG(3);
 
         String::Utf8Value _path (args[0]->ToString());
@@ -783,7 +784,7 @@ public:
         METHOD_EPILOG(zoo_aget_children2(zk->zhandle, *_path, watch, &strings_stat_completion, cb));
     }
 
-    static Handle<Value> AWGetChildren2 (const Arguments& args) {
+    static NAN_METHOD(AWGetChildren2) {
         AW_METHOD_PROLOG(3);
 
         String::Utf8Value _path (args[0]->ToString());
@@ -791,7 +792,7 @@ public:
         METHOD_EPILOG(zoo_awget_children2(zk->zhandle, *_path, &watcher_fn, cbw, &strings_stat_completion, cb));
     }
 
-    static Handle<Value> AGetAcl (const Arguments& args) {
+    static NAN_METHOD(AGetAcl) {
         A_METHOD_PROLOG(2);
 
         String::Utf8Value _path (args[0]->ToString());
@@ -799,7 +800,7 @@ public:
         METHOD_EPILOG(zoo_aget_acl(zk->zhandle, *_path, &acl_completion, cb));
     }
 
-    static Handle<Value> ASetAcl (const Arguments& args) {
+    static NAN_METHOD(ASetAcl) {
         A_METHOD_PROLOG(4);
 
         String::Utf8Value _path (args[0]->ToString());
@@ -816,7 +817,7 @@ public:
         METHOD_EPILOG(zoo_aset_acl(zk->zhandle, *_path, _version, aclv, void_completion, data));
     }
 
-    static Handle<Value> AddAuth (const Arguments& args) {
+    static NAN_METHOD(AddAuth) {
         A_METHOD_PROLOG(3);
 
         String::Utf8Value _scheme (args[0]->ToString());
@@ -889,39 +890,40 @@ public:
         CALLBACK_EPILOG();
     }
 
-    static Handle<Value> StatePropertyGetter (Local<String> property, const AccessorInfo& info) {
+    static NAN_PROPERTY_GETTER(StatePropertyGetter) {
         NanScope();
-        assert(info.This().IsEmpty() == false);
-        assert(info.This()->IsObject());
-        ZooKeeper *zk = ObjectWrap::Unwrap<ZooKeeper>(info.This());
+        assert(args.This().IsEmpty() == false);
+        assert(args.This()->IsObject());
+        ZooKeeper *zk = ObjectWrap::Unwrap<ZooKeeper>(args.This());
         assert(zk);
-        assert(zk->handle_ == info.This());
+        assert(zk->handle_ == args.This());
         NanReturnValue(Integer::New (zk->zhandle != 0 ? zoo_state(zk->zhandle) : 0));
     }
 
-    static Handle<Value> ClientidPropertyGetter (Local<String> property, const AccessorInfo& info) {
+    static NAN_PROPERTY_GETTER(ClientidPropertyGetter) {
         NanScope();
-        ZooKeeper *zk = ObjectWrap::Unwrap<ZooKeeper>(info.This());
+        ZooKeeper *zk = ObjectWrap::Unwrap<ZooKeeper>(args.This());
         assert(zk);
         NanReturnValue(zk->idAsString(zk->zhandle != 0 ? zoo_client_id(zk->zhandle)->client_id : zk->myid.client_id));
     }
-    static Handle<Value> ClientPasswordPropertyGetter (Local<String> property, const AccessorInfo& info) {
+
+    static NAN_PROPERTY_GETTER(ClientPasswordPropertyGetter) {
         NanScope();
-        ZooKeeper *zk = ObjectWrap::Unwrap<ZooKeeper>(info.This());
+        ZooKeeper *zk = ObjectWrap::Unwrap<ZooKeeper>(args.This());
         assert(zk);
         NanReturnValue(zk->PasswordToHexString(zk->zhandle != 0 ? zoo_client_id(zk->zhandle)->passwd : zk->myid.passwd));
     }
 
-    static Handle<Value> SessionTimeoutPropertyGetter (Local<String> property, const AccessorInfo& info) {
+    static NAN_PROPERTY_GETTER(SessionTimeoutPropertyGetter) {
         NanScope();
-        ZooKeeper *zk = ObjectWrap::Unwrap<ZooKeeper>(info.This());
+        ZooKeeper *zk = ObjectWrap::Unwrap<ZooKeeper>(args.This());
         assert(zk);
         NanReturnValue(Integer::New (zk->zhandle != 0 ? zoo_recv_timeout(zk->zhandle) : -1));
     }
 
-    static Handle<Value> IsUnrecoverablePropertyGetter (Local<String> property, const AccessorInfo& info) {
+    static NAN_PROPERTY_GETTER(IsUnrecoverablePropertyGetter) {
         NanScope();
-        ZooKeeper *zk = ObjectWrap::Unwrap<ZooKeeper>(info.This());
+        ZooKeeper *zk = ObjectWrap::Unwrap<ZooKeeper>(args.This());
         assert(zk);
         NanReturnValue(Integer::New (zk->zhandle != 0 ? is_unrecoverable(zk->zhandle) : 0));
     }
@@ -952,7 +954,7 @@ public:
         }
     }
 
-    static Handle<Value> Close (const Arguments& args) {
+    static NAN_METHOD(Close) {
         NanScope();
         ZooKeeper *zk = ObjectWrap::Unwrap<ZooKeeper>(args.This());
         assert(zk);

--- a/src/node-zk.cpp
+++ b/src/node-zk.cpp
@@ -640,7 +640,7 @@ public:
         CALLBACK_PROLOG(3);
 
         LOG_DEBUG(("rc=%d, rc_string=%s", rc, zerror(rc)));
-        argv[2] = rc == ZOK ? zkk->createStatObject (stat) : Object::Cast(*Null());
+        argv[2] = rc == ZOK ? zkk->createStatObject (stat) : NanNull().As<Object>();
 
         CALLBACK_EPILOG();
     }
@@ -665,12 +665,12 @@ public:
 
         LOG_DEBUG(("rc=%d, rc_string=%s, value=%s", rc, zerror(rc), value));
 
-        argv[2] = stat != 0 ? zkk->createStatObject (stat) : Object::Cast(*Null());
+        argv[2] = stat != 0 ? zkk->createStatObject (stat) : NanNull().As<Object>();
 
         if (value != 0) {
             argv[3] = BufferNew(value, value_len);
         } else {
-            argv[3] = String::Cast(*Null());
+            argv[3] = NanNull().As<Object>();
         }
 
         CALLBACK_EPILOG();
@@ -737,7 +737,7 @@ public:
             }
             argv[2] = ar;
         } else {
-            argv[2] = Object::Cast(*Null());
+            argv[2] = NanNull().As<Object>();
         }
 
         CALLBACK_EPILOG();
@@ -772,10 +772,10 @@ public:
             }
             argv[2] = ar;
         } else {
-            argv[2] = Object::Cast(*Null());
+            argv[2] = NanNull().As<Object>();
         }
 
-        argv[3] = (stat != 0 ? zkk->createStatObject (stat) : Object::Cast(*Null()));
+        argv[3] = (stat != 0 ? zkk->createStatObject (stat) : NanNull().As<Object>());
 
         CALLBACK_EPILOG();
     }
@@ -887,8 +887,8 @@ public:
         LOG_DEBUG(("rc=%d, rc_string=%s, acl_vector=%lp", rc, zerror(rc), acl));
         CALLBACK_PROLOG(4);
 
-        argv[2] = acl != NULL ? zkk->createAclObject(acl) : Object::Cast(*Null());
-        argv[3] = stat != NULL ? zkk->createStatObject(stat) : Object::Cast(*Null());
+        argv[2] = acl != NULL ? zkk->createAclObject(acl) : NanNull().As<Object>();
+        argv[3] = stat != NULL ? zkk->createStatObject(stat) : NanNull().As<Object>();
 
         deallocate_ACL_vector(acl);
 

--- a/src/node-zk.cpp
+++ b/src/node-zk.cpp
@@ -443,10 +443,10 @@ public:
 
         if (path != 0) {
             str = NanNew<String>(path);
-            LOG_DEBUG(("calling Emit(%s, path='%s')", *String::Utf8Value(event_name), path));
+            LOG_DEBUG(("calling Emit(%s, path='%s')", *NanUtf8String(NanNew(event_name)), path));
         } else {
             str = NanUndefined();
-            LOG_DEBUG(("calling Emit(%s, path=null)", *String::Utf8Value(event_name)));
+            LOG_DEBUG(("calling Emit(%s, path=null)", *NanUtf8String(NanNew(event_name))));
         }
 
         this->DoEmit(event_name, str);
@@ -577,14 +577,14 @@ public:
     static NAN_METHOD(ACreate) {
         A_METHOD_PROLOG(4);
 
-        String::Utf8Value _path (args[0]->ToString());
+        NanUtf8String _path (args[0]->ToString());
         uint32_t flags = args[2]->ToUint32()->Uint32Value();
 
         if (Buffer::HasInstance(args[1])) { // buffer
             Local<Object> _data = args[1]->ToObject();
             METHOD_EPILOG(zoo_acreate(zk->zhandle, *_path, BufferData(_data), BufferLength(_data), &ZOO_OPEN_ACL_UNSAFE, flags, string_completion, cb));
         } else {    // other
-            String::Utf8Value _data (args[1]->ToString());
+            NanUtf8String _data (args[1]->ToString());
             METHOD_EPILOG(zoo_acreate(zk->zhandle, *_path, *_data, _data.length(), &ZOO_OPEN_ACL_UNSAFE, flags, string_completion, cb));
         }
     }
@@ -607,7 +607,7 @@ public:
 
     static NAN_METHOD(ADelete) {
         A_METHOD_PROLOG(3);
-        String::Utf8Value _path (args[0]->ToString());
+        NanUtf8String _path (args[0]->ToString());
         uint32_t version = args[1]->ToUint32()->Uint32Value();
 
         struct completion_data *data = (struct completion_data *) malloc(sizeof(struct completion_data));
@@ -648,7 +648,7 @@ public:
     static NAN_METHOD(AExists) {
         A_METHOD_PROLOG(3);
 
-        String::Utf8Value _path (args[0]->ToString());
+        NanUtf8String _path (args[0]->ToString());
         bool watch = args[1]->ToBoolean()->BooleanValue();
 
         METHOD_EPILOG(zoo_aexists(zk->zhandle, *_path, watch, &stat_completion, cb));
@@ -656,7 +656,7 @@ public:
 
     static NAN_METHOD(AWExists) {
         AW_METHOD_PROLOG(3);
-        String::Utf8Value _path (args[0]->ToString());
+        NanUtf8String _path (args[0]->ToString());
         METHOD_EPILOG(zoo_awexists(zk->zhandle, *_path, &watcher_fn, cbw, &stat_completion, cb));
     }
 
@@ -681,7 +681,7 @@ public:
 
         ZooKeeper *zk = ObjectWrap::Unwrap<ZooKeeper>(args.This());   
         assert(zk);
-        String::Utf8Value _path (args[0]->ToString());
+        NanUtf8String _path (args[0]->ToString());
         uint32_t version = args[1]->ToUint32()->Uint32Value();
   
         int ret = zoo_delete(zk->zhandle, *_path, version);
@@ -691,7 +691,7 @@ public:
     static NAN_METHOD(AGet) {
         A_METHOD_PROLOG(3);
 
-        String::Utf8Value _path (args[0]->ToString());
+        NanUtf8String _path (args[0]->ToString());
         bool watch = args[1]->ToBoolean()->BooleanValue();
 
         METHOD_EPILOG(zoo_aget(zk->zhandle, *_path, watch, &data_completion, cb));
@@ -705,7 +705,7 @@ public:
     static NAN_METHOD(AWGet) {
         AW_METHOD_PROLOG(3);
 
-        String::Utf8Value _path (args[0]->ToString());
+        NanUtf8String _path (args[0]->ToString());
 
         METHOD_EPILOG(zoo_awget(zk->zhandle, *_path, &watcher_fn, cbw, &data_completion, cb));
     }
@@ -713,14 +713,14 @@ public:
     static NAN_METHOD(ASet) {
         A_METHOD_PROLOG(4);
 
-        String::Utf8Value _path (args[0]->ToString());
+        NanUtf8String _path (args[0]->ToString());
         uint32_t version = args[2]->ToUint32()->Uint32Value();
 
         if (Buffer::HasInstance(args[1])) { // buffer
             Local<Object> _data = args[1]->ToObject();
             METHOD_EPILOG(zoo_aset(zk->zhandle, *_path, BufferData(_data), BufferLength(_data), version, &stat_completion, cb));
         } else {    // other
-            String::Utf8Value _data(args[1]->ToString());
+            NanUtf8String _data(args[1]->ToString());
             METHOD_EPILOG(zoo_aset(zk->zhandle, *_path, *_data, _data.length(), version, &stat_completion, cb));
         }
     }
@@ -746,7 +746,7 @@ public:
     static NAN_METHOD(AGetChildren) {
         A_METHOD_PROLOG(3);
 
-        String::Utf8Value _path (args[0]->ToString());
+        NanUtf8String _path (args[0]->ToString());
         bool watch = args[1]->ToBoolean()->BooleanValue();
 
         METHOD_EPILOG(zoo_aget_children(zk->zhandle, *_path, watch, &strings_completion, cb));
@@ -755,7 +755,7 @@ public:
     static NAN_METHOD(AWGetChildren) {
         AW_METHOD_PROLOG(3);
 
-        String::Utf8Value _path (args[0]->ToString());
+        NanUtf8String _path (args[0]->ToString());
 
         METHOD_EPILOG(zoo_awget_children(zk->zhandle, *_path, &watcher_fn, cbw, &strings_completion, cb));
     }
@@ -783,7 +783,7 @@ public:
     static NAN_METHOD(AGetChildren2) {
         A_METHOD_PROLOG(3);
 
-        String::Utf8Value _path (args[0]->ToString());
+        NanUtf8String _path (args[0]->ToString());
         bool watch = args[1]->ToBoolean()->BooleanValue();
 
         METHOD_EPILOG(zoo_aget_children2(zk->zhandle, *_path, watch, &strings_stat_completion, cb));
@@ -792,7 +792,7 @@ public:
     static NAN_METHOD(AWGetChildren2) {
         AW_METHOD_PROLOG(3);
 
-        String::Utf8Value _path (args[0]->ToString());
+        NanUtf8String _path (args[0]->ToString());
 
         METHOD_EPILOG(zoo_awget_children2(zk->zhandle, *_path, &watcher_fn, cbw, &strings_stat_completion, cb));
     }
@@ -800,7 +800,7 @@ public:
     static NAN_METHOD(AGetAcl) {
         A_METHOD_PROLOG(2);
 
-        String::Utf8Value _path (args[0]->ToString());
+        NanUtf8String _path (args[0]->ToString());
 
         METHOD_EPILOG(zoo_aget_acl(zk->zhandle, *_path, &acl_completion, cb));
     }
@@ -808,7 +808,7 @@ public:
     static NAN_METHOD(ASetAcl) {
         A_METHOD_PROLOG(4);
 
-        String::Utf8Value _path (args[0]->ToString());
+        NanUtf8String _path (args[0]->ToString());
         uint32_t _version = args[1]->ToUint32()->Uint32Value();
         Local<Array> arr = Local<Array>::Cast(args[2]);
 
@@ -825,8 +825,8 @@ public:
     static NAN_METHOD(AddAuth) {
         A_METHOD_PROLOG(3);
 
-        String::Utf8Value _scheme (args[0]->ToString());
-        String::Utf8Value _auth (args[1]->ToString());
+        NanUtf8String _scheme (args[0]->ToString());
+        NanUtf8String _auth (args[1]->ToString());
 
         struct completion_data *data = (struct completion_data *) malloc(sizeof(struct completion_data));
         data->cb = cb;
@@ -865,8 +865,8 @@ public:
         for (int i = 0, l = aclv->count; i < l; i++) {
             Local<Object> obj = Local<Object>::Cast(arr->Get(i));
 
-            String::Utf8Value _scheme (obj->Get(NanNew<String>("scheme"))->ToString());
-            String::Utf8Value _auth (obj->Get(NanNew<String>("auth"))->ToString());
+            NanUtf8String _scheme (obj->Get(NanNew<String>("scheme"))->ToString());
+            NanUtf8String _auth (obj->Get(NanNew<String>("auth"))->ToString());
             uint32_t _perms = obj->Get(NanNew<String>("perms"))->ToUint32()->Uint32Value();
 
             struct Id id;

--- a/src/node-zk.cpp
+++ b/src/node-zk.cpp
@@ -46,11 +46,11 @@ namespace zk {
 #define _LLP_CAST_ (long long *)
 
 #define THROW_IF_NOT(condition, text) if (!(condition)) { \
-      return ThrowException(Exception::Error (String::New(text))); \
+      return ThrowException(Exception::Error (NanNew<String>(text))); \
     }
 
 #define THROW_IF_NOT_R(condition, text) if (!(condition)) { \
-      ThrowException(Exception::Error (String::New(text))); \
+      ThrowException(Exception::Error (NanNew<String>(text))); \
       return; \
     }
 
@@ -108,32 +108,32 @@ public:
         NODE_SET_PROTOTYPE_METHOD(constructor_template, "add_auth", AddAuth);
 
         //extern ZOOAPI struct ACL_vector ZOO_OPEN_ACL_UNSAFE;
-        Local<Object> acl_open = Object::New();
-        acl_open->Set(NanNew("perms"), Integer::New(ZOO_PERM_ALL), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+        Local<Object> acl_open = NanNew<Object>();
+        acl_open->Set(NanNew("perms"), NanNew<Integer>(ZOO_PERM_ALL), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
         acl_open->Set(NanNew("scheme"), NanNew("world"), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
         acl_open->Set(NanNew("auth"), NanNew("anyone"), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
         constructor_template->Set(NanNew("ZOO_OPEN_ACL_UNSAFE"), acl_open, static_cast<PropertyAttribute>(ReadOnly | DontDelete));
 
         //extern ZOOAPI struct ACL_vector ZOO_READ_ACL_UNSAFE;
-        Local<Object> acl_read = Object::New();
-        acl_read->Set(String::NewSymbol("perms"), Integer::New(ZOO_PERM_READ), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
-        acl_read->Set(String::NewSymbol("scheme"), String::NewSymbol("world"), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
-        acl_read->Set(String::NewSymbol("auth"), String::NewSymbol("anyone"), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
-        constructor_template->Set(String::NewSymbol("ZOO_READ_ACL_UNSAFE"), acl_read, static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+        Local<Object> acl_read = NanNew<Object>();
+        acl_read->Set(NanNew<String>("perms"), NanNew<Integer>(ZOO_PERM_READ), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+        acl_read->Set(NanNew<String>("scheme"), NanNew<String>("world"), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+        acl_read->Set(NanNew<String>("auth"), NanNew<String>("anyone"), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+        constructor_template->Set(NanNew<String>("ZOO_READ_ACL_UNSAFE"), acl_read, static_cast<PropertyAttribute>(ReadOnly | DontDelete));
 
         //extern ZOOAPI struct ACL_vector ZOO_CREATOR_ALL_ACL;
-        Local<Object> acl_creator = Object::New();
-        acl_creator->Set(String::NewSymbol("perms"), Integer::New(ZOO_PERM_ALL), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
-        acl_creator->Set(String::NewSymbol("scheme"), String::NewSymbol("auth"), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
-        acl_creator->Set(String::NewSymbol("auth"), String::NewSymbol(""), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
-        constructor_template->Set(String::NewSymbol("ZOO_CREATOR_ALL_ACL"), acl_creator, static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+        Local<Object> acl_creator = NanNew<Object>();
+        acl_creator->Set(NanNew<String>("perms"), NanNew<Integer>(ZOO_PERM_ALL), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+        acl_creator->Set(NanNew<String>("scheme"), NanNew<String>("auth"), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+        acl_creator->Set(NanNew<String>("auth"), NanNew<String>(""), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+        constructor_template->Set(NanNew<String>("ZOO_CREATOR_ALL_ACL"), acl_creator, static_cast<PropertyAttribute>(ReadOnly | DontDelete));
 
         //what's the advantage of using constructor_template->PrototypeTemplate()->SetAccessor ?
-        constructor_template->InstanceTemplate()->SetAccessor(String::NewSymbol("state"), StatePropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
-        constructor_template->InstanceTemplate()->SetAccessor(String::NewSymbol("client_id"), ClientidPropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
-        constructor_template->InstanceTemplate()->SetAccessor(String::NewSymbol("client_password"), ClientPasswordPropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
-        constructor_template->InstanceTemplate()->SetAccessor(String::NewSymbol("timeout"), SessionTimeoutPropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
-        constructor_template->InstanceTemplate()->SetAccessor(String::NewSymbol("is_unrecoverable"), IsUnrecoverablePropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
+        constructor_template->InstanceTemplate()->SetAccessor(NanNew<String>("state"), StatePropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
+        constructor_template->InstanceTemplate()->SetAccessor(NanNew<String>("client_id"), ClientidPropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
+        constructor_template->InstanceTemplate()->SetAccessor(NanNew<String>("client_password"), ClientPasswordPropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
+        constructor_template->InstanceTemplate()->SetAccessor(NanNew<String>("timeout"), SessionTimeoutPropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
+        constructor_template->InstanceTemplate()->SetAccessor(NanNew<String>("is_unrecoverable"), IsUnrecoverablePropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
 
         Local<Function> constructor = constructor_template->GetFunction();
 
@@ -219,7 +219,7 @@ public:
         NODE_DEFINE_CONSTANT(constructor, ZSESSIONMOVED);
 
 
-        target->Set(String::NewSymbol("ZooKeeper"), constructor);
+        target->Set(NanNew<String>("ZooKeeper"), constructor);
     }
 
     static NAN_METHOD(New) {
@@ -333,22 +333,22 @@ public:
         THROW_IF_NOT(args[0]->IsObject(), "Init argument must be an object");
         Local<Object> arg = args[0]->ToObject();
 
-        int32_t debug_level = arg->Get(String::NewSymbol("debug_level"))->ToInt32()->Value();
+        int32_t debug_level = arg->Get(NanNew<String>("debug_level"))->ToInt32()->Value();
         zoo_set_debug_level(static_cast<ZooLogLevel>(debug_level));
 
-        bool order = arg->Get(String::NewSymbol("host_order_deterministic"))->ToBoolean()->BooleanValue();
+        bool order = arg->Get(NanNew<String>("host_order_deterministic"))->ToBoolean()->BooleanValue();
         zoo_deterministic_conn_order(order); // enable deterministic order
 
-        String::AsciiValue _hostPort (arg->Get(String::NewSymbol("connect"))->ToString());
-        int32_t session_timeout = arg->Get(String::NewSymbol("timeout"))->ToInt32()->Value();
+        String::AsciiValue _hostPort (arg->Get(NanNew<String>("connect"))->ToString());
+        int32_t session_timeout = arg->Get(NanNew<String>("timeout"))->ToInt32()->Value();
         if (session_timeout == 0) {
             session_timeout = 20000;
         }
 
         clientid_t local_client;
         ZERO_MEM (local_client);
-        v8::Local<v8::Value> v8v_client_id = arg->Get(String::NewSymbol("client_id"));
-        v8::Local<v8::Value> v8v_client_password = arg->Get(String::NewSymbol("client_password"));
+        v8::Local<v8::Value> v8v_client_id = arg->Get(NanNew<String>("client_id"));
+        v8::Local<v8::Value> v8v_client_password = arg->Get(NanNew<String>("client_password"));
         bool id_and_password_defined = (!v8v_client_id->IsUndefined() && !v8v_client_password->IsUndefined());
         bool id_and_password_undefined = (v8v_client_id->IsUndefined() && v8v_client_password->IsUndefined());
         THROW_IF_NOT ((id_and_password_defined || id_and_password_undefined), 
@@ -407,7 +407,7 @@ public:
         NanEscapableScope();
         char idbuff [128] = {0};
         sprintf(idbuff, "%llx", _LL_CAST_ id);
-        return NanEscapeScope(String::NewSymbol(idbuff));
+        return NanEscapeScope(NanNew<String>(idbuff));
     }
 
     static void StringToId (v8::Local<v8::Value> s, int64_t *id) {
@@ -423,7 +423,7 @@ public:
             b += 2;
         }
         buff[ZOOKEEPER_PASSWORD_BYTE_COUNT * 2] = '\0';
-        return NanEscapeScope(String::NewSymbol(buff));
+        return NanEscapeScope(NanNew<String>(buff));
     }
 
     static void HexStringToPassword (v8::Local<v8::Value> s, char *p) {
@@ -440,10 +440,10 @@ public:
         Local<Value> str;
 
         if (path != 0) {
-            str = String::New(path);
+            str = NanNew<String>(path);
             LOG_DEBUG(("calling Emit(%s, path='%s')", *String::Utf8Value(event_name), path));
         } else {
-            str = Local<Value>::New(Undefined());
+            str = NanUndefined();
             LOG_DEBUG(("calling Emit(%s, path=null)", *String::Utf8Value(event_name)));
         }
 
@@ -452,7 +452,7 @@ public:
 
     void DoEmitClose (Handle<String> event_name, int code) {
         NanScope();
-        Local<Value> v8code = Number::New(code);
+        Local<Value> v8code = NanNew<Number>(code);
 
         this->DoEmit(event_name, v8code);
     }
@@ -461,11 +461,11 @@ public:
         NanScope();
 
         Local<Value> argv[3];
-        argv[0] = Local<Value>::New(event_name);
-        argv[1] = Local<Value>::New(handle_);
-        argv[2] = Local<Value>::New(data);
+        argv[0] = NanNew<String>(event_name);
+        argv[1] = NanNew<Object>(handle_);
+        argv[2] = NanNew<Value>(data);
 
-        Local<Value> emit_v = handle_->Get(String::NewSymbol("emit"));
+        Local<Value> emit_v = handle_->Get(NanNew<String>("emit"));
         assert(emit_v->IsFunction());
         Local<Function> emit_fn = emit_v.As<Function>();
         
@@ -489,8 +489,8 @@ public:
         assert(zkk);\
         assert(zkk->handle_ == zk_handle); \
         Local<Value> argv[args]; \
-        argv[0] = Int32::New(rc); \
-        argv[1] = String::NewSymbol (zerror(rc))
+        argv[0] = NanNew<Int32>(rc);           \
+        argv[1] = NanNew<String>(zerror(rc))
 
 #define CALLBACK_EPILOG() \
         TryCatch try_catch; \
@@ -518,7 +518,7 @@ public:
 
 #define METHOD_EPILOG(call) \
         int ret = (call); \
-        NanReturnValue(Int32::New(ret))
+        NanReturnValue(NanNew<Int32>(ret))
 
 #define WATCHER_PROLOG(args) \
         if (zoo_state(zh) == ZOO_EXPIRED_SESSION_STATE) { return; } \
@@ -533,12 +533,12 @@ public:
         assert(zk->handle_ == zk_handle); \
         assert(zk->zhandle == zh); \
         Local<Value> argv[args]; \
-        argv[0] = Integer::New(type); \
-        argv[1] = Integer::New(state); \
-        argv[2] = String::New(path); \
+        argv[0] = NanNew<Integer>(type);   \
+        argv[1] = NanNew<Integer>(state);  \
+        argv[2] = NanNew<String>(path);                                 \
         Local<Value> lv_hb = (*callback)->GetHiddenValue(HIDDEN_PROP_HANDBACK); \
         /* (*callback)->DeleteHiddenValue(HIDDEN_PROP_HANDBACK); */ \
-        argv[3] = Local<Value>::New(Undefined ()); \
+        argv[3] = NanUndefined();    \
         if (!lv_hb.IsEmpty()) argv[3] = lv_hb
 
 #define AW_METHOD_PROLOG(nargs) \
@@ -568,7 +568,7 @@ public:
         LOG_DEBUG(("rc=%d, rc_string=%s, path=%s, data=%lp", rc, zerror(rc), value, cb));
 
         CALLBACK_PROLOG(3);
-        argv[2] = String::New(value);
+        argv[2] = NanNew<String>(value);
         CALLBACK_EPILOG();
     }
 
@@ -618,19 +618,19 @@ public:
 
     Local<Object> createStatObject (const struct Stat *stat) {
         NanEscapableScope();
-        Local<Object> o = Object::New();
-        o->Set(String::NewSymbol("czxid"), Number::New(stat->czxid), ReadOnly);
-        o->Set(String::NewSymbol("mzxid"), Number::New(stat->mzxid), ReadOnly);
-        o->Set(String::NewSymbol("pzxid"), Number::New(stat->pzxid), ReadOnly);
-        o->Set(String::NewSymbol("dataLength"), Integer::New(stat->dataLength), ReadOnly);
-        o->Set(String::NewSymbol("numChildren"), Integer::New(stat->numChildren), ReadOnly);
-        o->Set(String::NewSymbol("version"), Integer::New(stat->version), ReadOnly);
-        o->Set(String::NewSymbol("cversion"), Integer::New(stat->cversion), ReadOnly);
-        o->Set(String::NewSymbol("aversion"), Integer::New(stat->aversion), ReadOnly);
-        o->Set(String::NewSymbol("ctime"), NODE_UNIXTIME_V8(stat->ctime/1000.), ReadOnly);
-        o->Set(String::NewSymbol("mtime"), NODE_UNIXTIME_V8(stat->mtime/1000.), ReadOnly);
-        o->Set(String::NewSymbol("ephemeralOwner"), idAsString(stat->ephemeralOwner), ReadOnly);
-        o->Set(String::NewSymbol("createdInThisSession"), Boolean::New(myid.client_id == stat->ephemeralOwner), ReadOnly);
+        Local<Object> o = NanNew<Object>();
+        o->Set(NanNew<String>("czxid"), NanNew<Number>(stat->czxid), ReadOnly);
+        o->Set(NanNew<String>("mzxid"), NanNew<Number>(stat->mzxid), ReadOnly);
+        o->Set(NanNew<String>("pzxid"), NanNew<Number>(stat->pzxid), ReadOnly);
+        o->Set(NanNew<String>("dataLength"), NanNew<Integer>(stat->dataLength), ReadOnly);
+        o->Set(NanNew<String>("numChildren"), NanNew<Integer>(stat->numChildren), ReadOnly);
+        o->Set(NanNew<String>("version"), NanNew<Integer>(stat->version), ReadOnly);
+        o->Set(NanNew<String>("cversion"), NanNew<Integer>(stat->cversion), ReadOnly);
+        o->Set(NanNew<String>("aversion"), NanNew<Integer>(stat->aversion), ReadOnly);
+        o->Set(NanNew<String>("ctime"), NODE_UNIXTIME_V8(stat->ctime/1000.), ReadOnly);
+        o->Set(NanNew<String>("mtime"), NODE_UNIXTIME_V8(stat->mtime/1000.), ReadOnly);
+        o->Set(NanNew<String>("ephemeralOwner"), idAsString(stat->ephemeralOwner), ReadOnly);
+        o->Set(NanNew<String>("createdInThisSession"), NanNew<Boolean>(myid.client_id == stat->ephemeralOwner), ReadOnly);
         return NanEscapeScope(o);
     }
 
@@ -683,7 +683,7 @@ public:
         uint32_t version = args[1]->ToUint32()->Uint32Value();
   
         int ret = zoo_delete(zk->zhandle, *_path, version);
-        NanReturnValue(Int32::New(ret));
+        NanReturnValue(NanNew<Int32>(ret));
     }
 
     static NAN_METHOD(AGet) {
@@ -729,9 +729,9 @@ public:
         LOG_DEBUG(("rc=%d, rc_string=%s", rc, zerror(rc)));
 
         if (strings != NULL) {
-            Local<Array> ar = Array::New((uint32_t)strings->count);
+            Local<Array> ar = NanNew<Array>((uint32_t)strings->count);
             for (uint32_t i = 0; i < (uint32_t)strings->count; ++i) {
-                ar->Set(i, String::New(strings->data[i]));
+                ar->Set(i, NanNew<String>(strings->data[i]));
             }
             argv[2] = ar;
         } else {
@@ -764,9 +764,9 @@ public:
         LOG_DEBUG(("rc=%d, rc_string=%s", rc, zerror(rc)));
 
         if (strings != NULL) {
-            Local<Array> ar = Array::New((uint32_t)strings->count);
+            Local<Array> ar = NanNew<Array>((uint32_t)strings->count);
             for (uint32_t i = 0; i < (uint32_t)strings->count; ++i) {
-                ar->Set(i, String::New(strings->data[i]));
+                ar->Set(i, NanNew<String>(strings->data[i]));
             }
             argv[2] = ar;
         } else {
@@ -837,15 +837,15 @@ public:
     Local<Object> createAclObject (struct ACL_vector *aclv) {
         NanEscapableScope();
 
-        Local<Array> arr = Array::New(aclv->count);
+        Local<Array> arr = NanNew<Array>(aclv->count);
 
         for (int i = 0; i < aclv->count; i++) {
             struct ACL *acl = &aclv->data[i];
 
-            Local<Object> obj = Object::New();
-            obj->Set(String::NewSymbol("perms"), Integer::New(acl->perms), ReadOnly);
-            obj->Set(String::NewSymbol("scheme"), String::New(acl->id.scheme), ReadOnly);
-            obj->Set(String::NewSymbol("auth"), String::New(acl->id.id), ReadOnly);
+            Local<Object> obj = NanNew<Object>();
+            obj->Set(NanNew<String>("perms"), NanNew<Integer>(acl->perms), ReadOnly);
+            obj->Set(NanNew<String>("scheme"), NanNew<String>(acl->id.scheme), ReadOnly);
+            obj->Set(NanNew<String>("auth"), NanNew<String>(acl->id.id), ReadOnly);
 
             arr->Set(i, obj);
         }
@@ -863,9 +863,9 @@ public:
         for (int i = 0, l = aclv->count; i < l; i++) {
             Local<Object> obj = Local<Object>::Cast(arr->Get(i));
 
-            String::Utf8Value _scheme (obj->Get(String::NewSymbol("scheme"))->ToString());
-            String::Utf8Value _auth (obj->Get(String::NewSymbol("auth"))->ToString());
-            uint32_t _perms = obj->Get(String::NewSymbol("perms"))->ToUint32()->Uint32Value();
+            String::Utf8Value _scheme (obj->Get(NanNew<String>("scheme"))->ToString());
+            String::Utf8Value _auth (obj->Get(NanNew<String>("auth"))->ToString());
+            uint32_t _perms = obj->Get(NanNew<String>("perms"))->ToUint32()->Uint32Value();
 
             struct Id id;
             struct ACL *acl = &aclv->data[i];
@@ -900,7 +900,7 @@ public:
         ZooKeeper *zk = ObjectWrap::Unwrap<ZooKeeper>(args.This());
         assert(zk);
         assert(zk->handle_ == args.This());
-        NanReturnValue(Integer::New (zk->zhandle != 0 ? zoo_state(zk->zhandle) : 0));
+        NanReturnValue(NanNew<Integer> (zk->zhandle != 0 ? zoo_state(zk->zhandle) : 0));
     }
 
     static NAN_PROPERTY_GETTER(ClientidPropertyGetter) {
@@ -921,14 +921,14 @@ public:
         NanScope();
         ZooKeeper *zk = ObjectWrap::Unwrap<ZooKeeper>(args.This());
         assert(zk);
-        NanReturnValue(Integer::New (zk->zhandle != 0 ? zoo_recv_timeout(zk->zhandle) : -1));
+        NanReturnValue(NanNew<Integer> (zk->zhandle != 0 ? zoo_recv_timeout(zk->zhandle) : -1));
     }
 
     static NAN_PROPERTY_GETTER(IsUnrecoverablePropertyGetter) {
         NanScope();
         ZooKeeper *zk = ObjectWrap::Unwrap<ZooKeeper>(args.This());
         assert(zk);
-        NanReturnValue(Integer::New (zk->zhandle != 0 ? is_unrecoverable(zk->zhandle) : 0));
+        NanReturnValue(NanNew<Integer> (zk->zhandle != 0 ? is_unrecoverable(zk->zhandle) : 0));
     }
 
     void realClose (int code) {

--- a/src/node-zk.cpp
+++ b/src/node-zk.cpp
@@ -288,7 +288,12 @@ public:
         zk->yield();
     }
 
+
+#if UV_VERSION_MAJOR > 0
+    static void zk_timer_cb (uv_timer_t *w) {
+#else
     static void zk_timer_cb (uv_timer_t *w, int status) {
+#endif
         LOG_DEBUG(("zk_timer_cb fired"));
 
         ZooKeeper *zk = static_cast<ZooKeeper*>(w->data);

--- a/src/node-zk.cpp
+++ b/src/node-zk.cpp
@@ -107,6 +107,14 @@ public:
         NODE_SET_PROTOTYPE_METHOD(constructor_template, "a_set_acl", ASetAcl);
         NODE_SET_PROTOTYPE_METHOD(constructor_template, "add_auth", AddAuth);
 
+        //what's the advantage of using constructor_template->PrototypeTemplate()->SetAccessor ?
+        constructor_template->InstanceTemplate()->SetAccessor(NanNew<String>("state"), StatePropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
+        constructor_template->InstanceTemplate()->SetAccessor(NanNew<String>("client_id"), ClientidPropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
+        constructor_template->InstanceTemplate()->SetAccessor(NanNew<String>("client_password"), ClientPasswordPropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
+        constructor_template->InstanceTemplate()->SetAccessor(NanNew<String>("timeout"), SessionTimeoutPropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
+        constructor_template->InstanceTemplate()->SetAccessor(NanNew<String>("is_unrecoverable"), IsUnrecoverablePropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
+
+
         Local<Function> constructor = constructor_template->GetFunction();
 
         //extern ZOOAPI struct ACL_vector ZOO_OPEN_ACL_UNSAFE;
@@ -129,13 +137,6 @@ public:
         acl_creator->ForceSet(NanNew<String>("scheme"), NanNew<String>("auth"), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
         acl_creator->ForceSet(NanNew<String>("auth"), NanNew<String>(""), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
         constructor->ForceSet(NanNew<String>("ZOO_CREATOR_ALL_ACL"), acl_creator, static_cast<PropertyAttribute>(ReadOnly | DontDelete));
-
-        //what's the advantage of using constructor_template->PrototypeTemplate()->SetAccessor ?
-        constructor_template->InstanceTemplate()->SetAccessor(NanNew<String>("state"), StatePropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
-        constructor_template->InstanceTemplate()->SetAccessor(NanNew<String>("client_id"), ClientidPropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
-        constructor_template->InstanceTemplate()->SetAccessor(NanNew<String>("client_password"), ClientPasswordPropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
-        constructor_template->InstanceTemplate()->SetAccessor(NanNew<String>("timeout"), SessionTimeoutPropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
-        constructor_template->InstanceTemplate()->SetAccessor(NanNew<String>("is_unrecoverable"), IsUnrecoverablePropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
 
 
         NODE_DEFINE_CONSTANT(constructor, ZOO_CREATED_EVENT);

--- a/src/node-zk.cpp
+++ b/src/node-zk.cpp
@@ -107,26 +107,28 @@ public:
         NODE_SET_PROTOTYPE_METHOD(constructor_template, "a_set_acl", ASetAcl);
         NODE_SET_PROTOTYPE_METHOD(constructor_template, "add_auth", AddAuth);
 
+        Local<Function> constructor = constructor_template->GetFunction();
+
         //extern ZOOAPI struct ACL_vector ZOO_OPEN_ACL_UNSAFE;
         Local<Object> acl_open = NanNew<Object>();
-        acl_open->Set(NanNew("perms"), NanNew<Integer>(ZOO_PERM_ALL), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
-        acl_open->Set(NanNew("scheme"), NanNew("world"), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
-        acl_open->Set(NanNew("auth"), NanNew("anyone"), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
-        constructor_template->Set(NanNew("ZOO_OPEN_ACL_UNSAFE"), acl_open, static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+        acl_open->ForceSet(NanNew("perms"), NanNew<Integer>(ZOO_PERM_ALL), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+        acl_open->ForceSet(NanNew("scheme"), NanNew("world"), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+        acl_open->ForceSet(NanNew("auth"), NanNew("anyone"), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+        constructor->ForceSet(NanNew("ZOO_OPEN_ACL_UNSAFE"), acl_open, static_cast<PropertyAttribute>(ReadOnly | DontDelete));
 
         //extern ZOOAPI struct ACL_vector ZOO_READ_ACL_UNSAFE;
         Local<Object> acl_read = NanNew<Object>();
-        acl_read->Set(NanNew<String>("perms"), NanNew<Integer>(ZOO_PERM_READ), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
-        acl_read->Set(NanNew<String>("scheme"), NanNew<String>("world"), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
-        acl_read->Set(NanNew<String>("auth"), NanNew<String>("anyone"), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
-        constructor_template->Set(NanNew<String>("ZOO_READ_ACL_UNSAFE"), acl_read, static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+        acl_read->ForceSet(NanNew<String>("perms"), NanNew<Integer>(ZOO_PERM_READ), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+        acl_read->ForceSet(NanNew<String>("scheme"), NanNew<String>("world"), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+        acl_read->ForceSet(NanNew<String>("auth"), NanNew<String>("anyone"), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+        constructor->ForceSet(NanNew<String>("ZOO_READ_ACL_UNSAFE"), acl_read, static_cast<PropertyAttribute>(ReadOnly | DontDelete));
 
         //extern ZOOAPI struct ACL_vector ZOO_CREATOR_ALL_ACL;
         Local<Object> acl_creator = NanNew<Object>();
-        acl_creator->Set(NanNew<String>("perms"), NanNew<Integer>(ZOO_PERM_ALL), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
-        acl_creator->Set(NanNew<String>("scheme"), NanNew<String>("auth"), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
-        acl_creator->Set(NanNew<String>("auth"), NanNew<String>(""), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
-        constructor_template->Set(NanNew<String>("ZOO_CREATOR_ALL_ACL"), acl_creator, static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+        acl_creator->ForceSet(NanNew<String>("perms"), NanNew<Integer>(ZOO_PERM_ALL), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+        acl_creator->ForceSet(NanNew<String>("scheme"), NanNew<String>("auth"), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+        acl_creator->ForceSet(NanNew<String>("auth"), NanNew<String>(""), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+        constructor->ForceSet(NanNew<String>("ZOO_CREATOR_ALL_ACL"), acl_creator, static_cast<PropertyAttribute>(ReadOnly | DontDelete));
 
         //what's the advantage of using constructor_template->PrototypeTemplate()->SetAccessor ?
         constructor_template->InstanceTemplate()->SetAccessor(NanNew<String>("state"), StatePropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
@@ -135,7 +137,6 @@ public:
         constructor_template->InstanceTemplate()->SetAccessor(NanNew<String>("timeout"), SessionTimeoutPropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
         constructor_template->InstanceTemplate()->SetAccessor(NanNew<String>("is_unrecoverable"), IsUnrecoverablePropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
 
-        Local<Function> constructor = constructor_template->GetFunction();
 
         NODE_DEFINE_CONSTANT(constructor, ZOO_CREATED_EVENT);
         NODE_DEFINE_CONSTANT(constructor, ZOO_DELETED_EVENT);
@@ -619,18 +620,18 @@ public:
     Local<Object> createStatObject (const struct Stat *stat) {
         NanEscapableScope();
         Local<Object> o = NanNew<Object>();
-        o->Set(NanNew<String>("czxid"), NanNew<Number>(stat->czxid), ReadOnly);
-        o->Set(NanNew<String>("mzxid"), NanNew<Number>(stat->mzxid), ReadOnly);
-        o->Set(NanNew<String>("pzxid"), NanNew<Number>(stat->pzxid), ReadOnly);
-        o->Set(NanNew<String>("dataLength"), NanNew<Integer>(stat->dataLength), ReadOnly);
-        o->Set(NanNew<String>("numChildren"), NanNew<Integer>(stat->numChildren), ReadOnly);
-        o->Set(NanNew<String>("version"), NanNew<Integer>(stat->version), ReadOnly);
-        o->Set(NanNew<String>("cversion"), NanNew<Integer>(stat->cversion), ReadOnly);
-        o->Set(NanNew<String>("aversion"), NanNew<Integer>(stat->aversion), ReadOnly);
-        o->Set(NanNew<String>("ctime"), NODE_UNIXTIME_V8(stat->ctime/1000.), ReadOnly);
-        o->Set(NanNew<String>("mtime"), NODE_UNIXTIME_V8(stat->mtime/1000.), ReadOnly);
-        o->Set(NanNew<String>("ephemeralOwner"), idAsString(stat->ephemeralOwner), ReadOnly);
-        o->Set(NanNew<String>("createdInThisSession"), NanNew<Boolean>(myid.client_id == stat->ephemeralOwner), ReadOnly);
+        o->ForceSet(NanNew<String>("czxid"), NanNew<Number>(stat->czxid), ReadOnly);
+        o->ForceSet(NanNew<String>("mzxid"), NanNew<Number>(stat->mzxid), ReadOnly);
+        o->ForceSet(NanNew<String>("pzxid"), NanNew<Number>(stat->pzxid), ReadOnly);
+        o->ForceSet(NanNew<String>("dataLength"), NanNew<Integer>(stat->dataLength), ReadOnly);
+        o->ForceSet(NanNew<String>("numChildren"), NanNew<Integer>(stat->numChildren), ReadOnly);
+        o->ForceSet(NanNew<String>("version"), NanNew<Integer>(stat->version), ReadOnly);
+        o->ForceSet(NanNew<String>("cversion"), NanNew<Integer>(stat->cversion), ReadOnly);
+        o->ForceSet(NanNew<String>("aversion"), NanNew<Integer>(stat->aversion), ReadOnly);
+        o->ForceSet(NanNew<String>("ctime"), NODE_UNIXTIME_V8(stat->ctime/1000.), ReadOnly);
+        o->ForceSet(NanNew<String>("mtime"), NODE_UNIXTIME_V8(stat->mtime/1000.), ReadOnly);
+        o->ForceSet(NanNew<String>("ephemeralOwner"), idAsString(stat->ephemeralOwner), ReadOnly);
+        o->ForceSet(NanNew<String>("createdInThisSession"), NanNew<Boolean>(myid.client_id == stat->ephemeralOwner), ReadOnly);
         return NanEscapeScope(o);
     }
 
@@ -843,9 +844,9 @@ public:
             struct ACL *acl = &aclv->data[i];
 
             Local<Object> obj = NanNew<Object>();
-            obj->Set(NanNew<String>("perms"), NanNew<Integer>(acl->perms), ReadOnly);
-            obj->Set(NanNew<String>("scheme"), NanNew<String>(acl->id.scheme), ReadOnly);
-            obj->Set(NanNew<String>("auth"), NanNew<String>(acl->id.id), ReadOnly);
+            obj->ForceSet(NanNew<String>("perms"), NanNew<Integer>(acl->perms), ReadOnly);
+            obj->ForceSet(NanNew<String>("scheme"), NanNew<String>(acl->id.scheme), ReadOnly);
+            obj->ForceSet(NanNew<String>("auth"), NanNew<String>(acl->id.id), ReadOnly);
 
             arr->Set(i, obj);
         }

--- a/src/node-zk.cpp
+++ b/src/node-zk.cpp
@@ -467,13 +467,13 @@ public:
         argv[1] = NanObjectWrapHandle(this);
         argv[2] = NanNew<Value>(data);
 
-        Local<Value> emit_v = handle_->Get(NanNew<String>("emit"));
+        Local<Value> emit_v = NanObjectWrapHandle(this)->Get(NanNew<String>("emit"));
         assert(emit_v->IsFunction());
         Local<Function> emit_fn = emit_v.As<Function>();
         
         TryCatch tc;
 
-        emit_fn->Call(handle_, 3, argv);
+        emit_fn->Call(NanObjectWrapHandle(this), 3, argv);
 
         if(tc.HasCaught()) {
             FatalException(tc);
@@ -489,7 +489,7 @@ public:
         Local<Object> zk_handle = Local<Object>::Cast(lv); \
         ZooKeeper *zkk = ObjectWrap::Unwrap<ZooKeeper>(zk_handle); \
         assert(zkk);\
-        assert(zkk->handle_ == zk_handle); \
+        assert(NanObjectWrapHandle(zkk) == zk_handle);  \
         Local<Value> argv[args]; \
         argv[0] = NanNew<Int32>(rc);           \
         argv[1] = NanNew<String>(zerror(rc))
@@ -516,7 +516,7 @@ public:
         THROW_IF_NOT (args.Length() >= nargs, "expected "#nargs" arguments") \
         assert (args[nargs-1]->IsFunction()); \
         Persistent<Function> *cb = cb_persist (args[nargs-1]); \
-        (*cb)->SetHiddenValue(HIDDEN_PROP_ZK, zk->handle_); \
+        (*cb)->SetHiddenValue(HIDDEN_PROP_ZK, NanObjectWrapHandle(zk)); \
 
 #define METHOD_EPILOG(call) \
         int ret = (call); \
@@ -532,7 +532,7 @@ public:
         Local<Object> zk_handle = Local<Object>::Cast(lv_zk); \
         ZooKeeper *zk = ObjectWrap::Unwrap<ZooKeeper>(zk_handle); \
         assert(zk);\
-        assert(zk->handle_ == zk_handle); \
+        assert(NanObjectWrapHandle(zk) == zk_handle);   \
         assert(zk->zhandle == zh); \
         Local<Value> argv[args]; \
         argv[0] = NanNew<Integer>(type);   \
@@ -550,11 +550,11 @@ public:
         THROW_IF_NOT (args.Length() >= nargs, "expected at least "#nargs" arguments") \
         assert (args[nargs-1]->IsFunction()); \
         Persistent<Function> *cb = cb_persist (args[nargs-1]); \
-        (*cb)->SetHiddenValue(HIDDEN_PROP_ZK, zk->handle_); \
+        (*cb)->SetHiddenValue(HIDDEN_PROP_ZK, NanObjectWrapHandle(zk)); \
         \
         assert (args[nargs-2]->IsFunction()); \
         Persistent<Function> *cbw = cb_persist (args[nargs-2]); \
-        (*cbw)->SetHiddenValue(HIDDEN_PROP_ZK, zk->handle_)
+        (*cbw)->SetHiddenValue(HIDDEN_PROP_ZK, NanObjectWrapHandle(zk))
 
 /*
         if (args.Length() > nargs) { \
@@ -901,7 +901,7 @@ public:
         assert(args.This()->IsObject());
         ZooKeeper *zk = ObjectWrap::Unwrap<ZooKeeper>(args.This());
         assert(zk);
-        assert(zk->handle_ == args.This());
+        assert(NanObjectWrapHandle(zk) == args.This());
         NanReturnValue(NanNew<Integer> (zk->zhandle != 0 ? zoo_state(zk->zhandle) : 0));
     }
 

--- a/src/node-zk.cpp
+++ b/src/node-zk.cpp
@@ -467,23 +467,14 @@ public:
 
     void DoEmit (Local<String> event_name, Handle<Value> data) {
         NanScope();
+        Local<Object> thisObj = NanObjectWrapHandle(this);
 
         Local<Value> argv[3];
         argv[0] = event_name;
-        argv[1] = NanObjectWrapHandle(this);
+        argv[1] = thisObj;
         argv[2] = NanNew<Value>(data);
 
-        Local<Value> emit_v = NanObjectWrapHandle(this)->Get(NanNew<String>("emit"));
-        assert(emit_v->IsFunction());
-        Local<Function> emit_fn = emit_v.As<Function>();
-        
-        TryCatch tc;
-
-        emit_fn->Call(NanObjectWrapHandle(this), 3, argv);
-
-        if(tc.HasCaught()) {
-            FatalException(tc);
-        }
+        NanMakeCallback(thisObj, "emit", 3, argv);
     }
 
 #define CALLBACK_PROLOG(args) \
@@ -501,19 +492,11 @@ public:
         argv[1] = NanNew<String>(zerror(rc))
 
 #define CALLBACK_EPILOG() \
-        TryCatch try_catch; \
         callback->Call(sizeof(argv)/sizeof(argv[0]), argv); \
-        if (try_catch.HasCaught()) { \
-            FatalException(try_catch); \
-        }; \
         delete callback
 
 #define WATCHER_CALLBACK_EPILOG() \
-        TryCatch try_catch; \
         callback->Call(sizeof(argv)/sizeof(argv[0]), argv); \
-        if (try_catch.HasCaught()) { \
-            FatalException(try_catch); \
-        };
 
 #define A_METHOD_PROLOG(nargs) \
         NanScope();                                                       \

--- a/src/node-zk.cpp
+++ b/src/node-zk.cpp
@@ -340,7 +340,7 @@ public:
         bool order = arg->Get(NanNew<String>("host_order_deterministic"))->ToBoolean()->BooleanValue();
         zoo_deterministic_conn_order(order); // enable deterministic order
 
-        String::AsciiValue _hostPort (arg->Get(NanNew<String>("connect"))->ToString());
+        NanAsciiString _hostPort (arg->Get(NanNew<String>("connect"))->ToString());
         int32_t session_timeout = arg->Get(NanNew<String>("timeout"))->ToInt32()->Value();
         if (session_timeout == 0) {
             session_timeout = 20000;
@@ -355,7 +355,7 @@ public:
         THROW_IF_NOT ((id_and_password_defined || id_and_password_undefined), 
             "ZK init: client id and password must either be both specified or unspecified");
         if (id_and_password_defined) {
-          String::AsciiValue password_check(v8v_client_password->ToString());
+          NanAsciiString password_check(v8v_client_password->ToString());
           THROW_IF_NOT (password_check.length() == 2 * ZOOKEEPER_PASSWORD_BYTE_COUNT, 
               "ZK init: password does not have correct length");
           HexStringToPassword(v8v_client_password, local_client.passwd);
@@ -413,7 +413,7 @@ public:
     }
 
     static void StringToId (v8::Local<v8::Value> s, int64_t *id) {
-        String::AsciiValue a(s->ToString());
+        NanAsciiString a(s->ToString());
         sscanf(*a, "%llx", _LLP_CAST_ id);
     }
 
@@ -429,7 +429,7 @@ public:
     }
 
     static void HexStringToPassword (v8::Local<v8::Value> s, char *p) {
-        String::AsciiValue a(s->ToString());
+        NanAsciiString a(s->ToString());
         char *hex = *a;
         for (int i = 0; i < ZOOKEEPER_PASSWORD_BYTE_COUNT; ++i) {
           hexToUchar(hex, (unsigned char *)p+i);

--- a/test/zk_test_mkdirp.js
+++ b/test/zk_test_mkdirp.js
@@ -3,6 +3,8 @@ var assert = require('assert');
 var log4js = require('log4js');
 var async = require('async');
 
+var connect  = (process.argv[2] || 'localhost:2181');
+
 //
 // based on node-leader
 // https://github.com/mcavage/node-leader
@@ -45,7 +47,7 @@ function startZK(options, callback) {
 
 if (require.main === module) {
   var options = {
-    zookeeper: 'localhost:2181',
+    zookeeper: connect,
     log4js: log4js
   };
 


### PR DESCRIPTION
This branch includes the adoption of the 'nan' library so that both 0.10 and 0.12 node versions can be supported at once.  

I've intentionally broken up the adoption into many different commits, so that a reviewer can follow my adoption strategy.  At each step, the code continues to compile with 0.10 and slowly reduces compile errors in 0.12.  At the end, the the commits, both compile cleanly.

This branch fixes #108