### PR TITLE
Don't corrupt memory

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
    "name": "zookeeper"
   ,"description": "apache zookeeper client (zookeeper async API >= 3.4.0)"
-  ,"version": "3.4.9-1"
+  ,"version": "3.4.9-2"
   ,"author": "Yuri Finkelstein <yurif2003@yahoo.com>"
   ,"contributors": [
     "Yuri Finkelstein <yurif2003@yahoo.com>"


### PR DESCRIPTION
Do not double initailize a uv_poll_t structure and always close handles before deletion

Fixes #133