### PR TITLE
Fix build on macOs Mojave with Xcode 10

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -25,7 +25,11 @@
                 ],
                 'libraries': ['<(module_root_dir)/deps/zookeeper/src/c/.libs/libzookeeper_st.a'],
                 'xcode_settings': {
-                    'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
+                    'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+                    'MACOSX_DEPLOYMENT_TARGET': '10.7',
+                    'GCC_VERSION': 'com.apple.compilers.llvm.clang.1_0',
+                    'CLANG_CXX_LANGUAGE_STANDARD': 'gnu++1y',  # -std=gnu++1y
+                    'CLANG_CXX_LIBRARY': 'libc++',
                 }
             }],['OS=="linux"',{
                 'include_dirs': [

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
 module.exports = require('./zookeeper');
 module.exports.ZooKeeper = module.exports;  // for backwards compatibility
 module.exports.Promise = require('./zk_promise');
+module.exports.NativeZk = require(__dirname + '/../build/zookeeper.node').ZooKeeper;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-   "name": "zookeeper"
+   "name": "zk-zookeeper"
   ,"description": "apache zookeeper client (zookeeper async API >= 3.4.0)"
   ,"version": "3.4.9-3"
   ,"author": "Yuri Finkelstein <yurif2003@yahoo.com>"
@@ -16,7 +16,7 @@
   ]
   ,"repository": {
       "type": "git"
-      ,"url": "https://github.com/yfinkelstein/node-zookeeper"
+      ,"url": "https://github.com/oleksiyk/node-zookeeper"
   }
   ,"keywords": ["apache", "zookeeper", "client"]
   ,"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
    "name": "zk-zookeeper"
   ,"description": "apache zookeeper client (zookeeper async API >= 3.4.0)"
-  ,"version": "3.4.9-3"
+  ,"version": "3.4.9-4"
   ,"author": "Yuri Finkelstein <yurif2003@yahoo.com>"
   ,"contributors": [
     "Yuri Finkelstein <yurif2003@yahoo.com>"


### PR DESCRIPTION
This fixes build issue with Xcode where it couldn't find C++ include files:

```
  CXX(target) Release/obj.target/zookeeper/src/node-zk.o
warning: include path for stdlibc++ headers not found; pass '-std=libc++' on the command line to use
      the libc++ standard library instead [-Wstdlibcxx-not-found]
In file included from ../src/node-zk.cpp:14:
../node_modules/nan/nan.h:50:10: fatal error: 'algorithm' file not found
#include <algorithm>
         ^~~~~~~~~~~
1 warning and 1 error generated.
make: *** [Release/obj.target/zookeeper/src/node-zk.o] Error 1
```