### PR TITLE
fix missing to install on Windows 7

### DIFF
--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -45,11 +45,8 @@ function validateFile(fileName) {
 
         // `certutil` returns 2byte separated string (e.g. "a9 89 b5 27 f3 f9 90 d4 71 e6 d4 7e e4 10 e5 7d 8b e7 62 0b")
         const sha1 = output[1].replace(/ /g, "");
-        // fileName validation (?) (double check ..?)
-        const arr = output[0].replace(':', '').split(' ');
-        const name = arr.find(n => n === fileName);
 
-        res = `${sha1}  ${name}`;
+        res = `${sha1}  ${fileName}`;
     } else {
         res = exec(`shasum -a 1 ${fileName}`).trim();
     }

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -41,7 +41,7 @@ function validateFile(fileName) {
     let res;
 
     if (env.isWindows) {
-        const output = exec(`certutil -hashfile ${fileName} sha1`).split('\r\n');
+        const output = exec(`certutil -hashfile ${fileName} SHA1`).split('\r\n');
 
         const arr = output[0].replace(':', '').split(' ');
         const name = arr.find(n => n === fileName);

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -43,10 +43,12 @@ function validateFile(fileName) {
     if (env.isWindows) {
         const output = exec(`certutil -hashfile ${fileName} SHA1`).split('\r\n');
 
+        // `certutil` returns 2byte separated string (e.g. "a9 89 b5 27 f3 f9 90 d4 71 e6 d4 7e e4 10 e5 7d 8b e7 62 0b")
+        const sha1 = output[1].replace(/ /g, "");
+        // fileName validation (?) (double check ..?)
         const arr = output[0].replace(':', '').split(' ');
         const name = arr.find(n => n === fileName);
 
-        const sha1 = output[1];
         res = `${sha1}  ${name}`;
     } else {
         res = exec(`shasum -a 1 ${fileName}`).trim();


### PR DESCRIPTION
Windows 7's `certutil` has some differences as Windows 10's one.

If this Pull Request will be merged, we can `npm install zookeeper` on Windows 7.

## install zookeeper@4.0.1 on Windows 7

result: 

```
C:\tmp\a>npm i zookeeper

> zookeeper@4.0.1 install C:\tmp\a\node_modules\zookeeper
> node ./scripts/prepublish.js && npm run build

cd C:\tmp\a\node_modules\zookeeper/deps
exec certutil -hashfile zookeeper-3.4.13.tar.gz sha1
CertUtil: -hashfile �R�}���h �G���[�ł�: 0xd00000bb (-805306181)
CertUtil: WsResetMetadata
echo Unable to download zookeeper library. Error: exec:
Unable to download zookeeper library. Error: exec:
npm WARN a@1.0.0 No description
npm WARN a@1.0.0 No repository field.

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! zookeeper@4.0.1 install: `node ./scripts/prepublish.js && npm run build`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the zookeeper@4.0.1 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\ndxbn\AppData\Roaming\npm-cache\_logs\2019-04-09T09_13_42_556Z-debug.log

C:\tmp\a>
```

## Why we cannot install on Windows 7 ?

with [this patch](https://github.com/ndxbn/node-zookeeper/pull/1/files), result is

```
C:\tmp\a>npm i ./node-zookeeper

> zookeeper@4.0.1 install C:\tmp\a\node_modules\zookeeper
> node ./scripts/prepublish.js && npm run build

cd C:\tmp\a\node_modules\zookeeper/deps
exec certutil -hashfile zookeeper-3.4.13.tar.gz SHA1
SHA1 �n�b�V�� (�t�@�C�� zookeeper-3.4.13.tar.gz):
a9 89 b5 27 f3 f9 90 d4 71 e6 d4 7e e4 10 e5 7d 8b e7 62 0b
CertUtil: -hashfile �R�}���h�͐���Ɋ������܂����B
[ 'SHA1 �n�b�V�� (�t�@�C�� zookeeper-3.4.13.tar.gz):',
  'a9 89 b5 27 f3 f9 90 d4 71 e6 d4 7e e4 10 e5 7d 8b e7 62 0b',
  'CertUtil: -hashfile �R�}���h�͐���Ɋ������܂����B',
  '' ]
echo Unable to download zookeeper library. Error: Wrong sha1 for zookeeper-3.4.13.tar.gz! Expected "a989b527f3f990d471e6d47ee410e57d8be7620b  zookeeper-3.4.13.tar.gz", got "a9 89 b5 27 f3 f9 90 d4 71 e6 d4 7e e4 10 e5 7d 8b e7 62 0b  undefined".
Unable to download zookeeper library. Error: Wrong sha1 for zookeeper-3.4.13.tar.gz! Expected "a989b527f3f990d471e6d47ee410e57d8be7620b  zookeeper-3.4.13.tar.gz", got "a9 89 b5 27 f3 f9 90 d4 71 e6 d4 7e e4 10 e5 7d 8b e7 62 0b  undefined".
npm WARN a@1.0.0 No description
npm WARN a@1.0.0 No repository field.

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! zookeeper@4.0.1 install: `node ./scripts/prepublish.js && npm run build`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the zookeeper@4.0.1 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\ndxbn\AppData\Roaming\npm-cache\_logs\2019-04-09T09_19_14_491Z-debug.log
```

pick up `certutil` result: 

```javascript
[ 'SHA1 �n�b�V�� (�t�@�C�� zookeeper-3.4.13.tar.gz):',
  'a9 89 b5 27 f3 f9 90 d4 71 e6 d4 7e e4 10 e5 7d 8b e7 62 0b',
  'CertUtil: -hashfile �R�}���h�͐���Ɋ������܂����B',
  '' ]
```

So, 

- `sha1`: expect `a989b527f3f990d471e6d47ee410e57d8be7620b`, actually `a9 89 b5 27 f3 f9 90 d4 71 e6 d4 7e e4 10 e5 7d 8b e7 62 0b`
- `fileName`: expect `zookeeper-3.4.13.tar.gz`, actually `zookeeper-3.4.13.tar.gz)`

fail to validation and miss to install on Windows7.
