### PR TITLE
Refactor deprecated JavaScript gettter/setter feature

### DIFF
--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -70,7 +70,7 @@ function ZooKeeper(config) {
         // then data will be a buffer
         return self.encoding ? false : true;
       },
-      set: function () {
+      set: function (data_as_buffer) {
         // if the data is a buffer, then there's no encoding. If the data is NOT a buffer, then the default encoding is 'utf8'
         self.encoding = ((data_as_buffer == true) ? null : 'utf8');
       }

--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -38,11 +38,15 @@ function ZooKeeper(config) {
   ////////////////////////////////////////////////////////////////////////////////
 
   function proxyProperty(name) {
-    self.__defineGetter__(name, function(){
-      return self._native[name];
-    });
-    self.__defineSetter__(name, function(val){
-      self._native[name] = val;
+    Object.defineProperties(self, {
+      [name]: {
+        get: function () {
+          return self._native[name];
+        },
+        set: function (value) {
+          self._native[name] = value;
+        }
+      }
     });
   }
 
@@ -59,16 +63,19 @@ function ZooKeeper(config) {
   };
 
   // Backwards Compat for 'data_as_buffer' property.  deprecated.  just use setEncoding()
-  self.__defineGetter__('data_as_buffer', function(){
-    // if there's an encoding, then data isn't a buffer.  If there's no encoding,
-    // then data will be a buffer
-    return self.encoding ? false : true;
+  Object.defineProperties(self, {
+    'data_as_buffer': {
+      get: function () {
+        // if there's an encoding, then data isn't a buffer.  If there's no encoding,
+        // then data will be a buffer
+        return self.encoding ? false : true;
+      },
+      set: function () {
+        // if the data is a buffer, then there's no encoding. If the data is NOT a buffer, then the default encoding is 'utf8'
+        self.encoding = ((data_as_buffer == true) ? null : 'utf8');
+      }
+    }
   });
-  self.__defineSetter__('data_as_buffer', function(data_as_buffer){
-    // if the data is a buffer, then there's no encoding. If the data is NOT a buffer, then the default encoding is 'utf8'
-    self.encoding = ((data_as_buffer == true) ? null : 'utf8');
-  });
-
 }
 
 util.inherits(ZooKeeper, EventEmitter);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As the `__defineGetter__`/`__defineSetter__` is being deprecated, I'm going to replace it with [Object.defineProperties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperties).

## Motivation and Context
This PR addresses Issue #149.

## How Has This Been Tested?
```
npm test
npm run integrationtest
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have read the [code of conduct](https://github.com/yfinkelstein/node-zookeeper/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/yfinkelstein/node-zookeeper/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
