### PR TITLE
Reduce build output on Unix systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,16 @@ For more details please refer to ZooKeeper docs.
 # Windows support
 Install `CMake` to build a ZooKeeper client on Windows. `Python 2.7.x` is currently required by the tool `node-gyp` to build the ZooKeeper client as a native Node.js Addon. 
 
-Also, run `npm install` in a Powershell window as an __Administrator__.
+Also, run `npm install` in a Powershell window as an __Administrator__. For further instructions visit [node-gyp documentation](https://github.com/nodejs/node-gyp/#on-windows).
 
 Windows support has been enabled mainly for supporting development, not for production.
+
+# Development
+
+To run full output during the module build one has to use `ZK_INSTALL_VERBOSE` flag.
+
+`ZK_INSTALL_VERBOSE=1 npm install`
+
 # Implementation Notes
 
 ### NOTE on Module Status (DDOPSON-2011-11-30):

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -35,11 +35,15 @@ if (env.isWindows) {
     exec(`cmake -DWANT_SYNCAPI=OFF -DCMAKE_GENERATOR_PLATFORM=${process.arch} .`);
     exec('cmake --build .');
 } else {
-    exec('./configure --without-syncapi --disable-shared --with-pic');
-    exec('make');
+    let configureCmd = './configure --without-syncapi --disable-shared --with-pic';
+    let makeCmd = 'make'
+    if (!process.env.ZK_INSTALL_VERBOSE) {
+        configureCmd += ' --enable-silent-rules --quiet';
+        makeCmd += ' --no-print-directory --quiet';
+    }
+    exec(configureCmd);
+    exec(makeCmd);
 }
 
 shell.cd(env.rootFolder);
-
-
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -36,7 +36,7 @@ if (env.isWindows) {
     exec('cmake --build .');
 } else {
     let configureCmd = './configure --without-syncapi --disable-shared --with-pic';
-    let makeCmd = 'make'
+    let makeCmd = 'make';
     if (!process.env.ZK_INSTALL_VERBOSE) {
         configureCmd += ' --enable-silent-rules --quiet';
         makeCmd += ' --no-print-directory --quiet';


### PR DESCRIPTION
## Description
Reduces amount of output logs produced by `configure` and `make` commands during the build process.

## Motivation and Context
Please see corresponding issue #182 for more information.

## How Has This Been Tested?
`npm install` -> produces less output
`ZK_INSTALL_VERBOSE=1 npm install` -> produces full output

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have read the [code of conduct](https://github.com/yfinkelstein/node-zookeeper/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/yfinkelstein/node-zookeeper/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly (if applicable).
