### PR TITLE
Windows: quicker build

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,16 @@ To run full output during the module build one has to use `ZK_INSTALL_VERBOSE` f
 
 `ZK_INSTALL_VERBOSE=1 npm install`
 
+##### For Windows (PowerShell): verbose build #####
+```bash
+$env:ZK_INSTALL_VERBOSE=1 
+npm install
+```
+This PowerShell command will remove the environment variable:
+```bash
+Remove-Item Env:\ZK_INSTALL_VERBOSE
+```
+
 # Implementation Notes
 
 ### NOTE on Module Status (DDOPSON-2011-11-30):

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ For more details please refer to ZooKeeper docs.
 # Windows support
 Install `CMake` to build a ZooKeeper client on Windows. `Python 2.7.x` is currently required by the tool `node-gyp` to build the ZooKeeper client as a native Node.js Addon. 
 
-Also, run `npm install` in a Powershell window as an __Administrator__. For further instructions visit [node-gyp documentation](https://github.com/nodejs/node-gyp/#on-windows).
+Also, run `npm install` in a Powershell window. For further instructions visit [node-gyp documentation](https://github.com/nodejs/node-gyp/#on-windows).
 
 Windows support has been enabled mainly for supporting development, not for production.
 

--- a/patches/CMakeLists.txt
+++ b/patches/CMakeLists.txt
@@ -1,0 +1,68 @@
+cmake_minimum_required(VERSION 3.6)
+
+project(zookeeper VERSION 3.4.13)
+set(email user@zookeeper.apache.org)
+set(description "zookeeper C client")
+
+# general options
+include_directories(include tests generated ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
+add_compile_options(/W0)
+add_definitions(-DUSE_STATIC_LIB)
+
+# CppUnit option
+set(DEFAULT_WANT_CPPUNIT OFF)
+option(WANT_CPPUNIT "Enables CppUnit and tests" ${DEFAULT_WANT_CPPUNIT})
+
+# The function `to_have(in out)` converts a header name like `arpa/inet.h`
+# into an Autotools style preprocessor definition `HAVE_ARPA_INET_H`.
+# This is then set or unset in `configure_file()` step.
+#
+# Note that CMake functions do not have return values; instead an "out"
+# variable must be passed, and explicitly set with parent scope.
+function(to_have in out)
+  string(TOUPPER ${in} str)
+  string(REGEX REPLACE "/|\\." "_" str ${str})
+  set(${out} "HAVE_${str}" PARENT_SCOPE)
+endfunction()
+
+# include file checks
+foreach(f generated/zookeeper.jute.h generated/zookeeper.jute.c)
+  if(EXISTS "${CMAKE_SOURCE_DIR}/${f}")
+    to_have(${f} name)
+    set(${name} 1)
+  else()
+    message(FATAL_ERROR
+      "jute files are missing!\n"
+      "Please run 'ant compile_jute' while in the ZooKeeper top level directory.")
+  endif()
+endforeach()
+
+# configure
+configure_file(cmake_config.h.in ${CMAKE_SOURCE_DIR}/include/config.h)
+
+# hashtable library
+set(hashtable_sources src/hashtable/hashtable_itr.c src/hashtable/hashtable.c)
+add_library(hashtable STATIC ${hashtable_sources})
+target_link_libraries(hashtable PUBLIC $<$<PLATFORM_ID:Linux>:m>)
+
+# zookeeper library
+set(zookeeper_sources
+  src/zookeeper.c
+  src/recordio.c
+  generated/zookeeper.jute.c
+  src/zk_log.c
+  src/zk_hashtable.c)
+
+list(APPEND zookeeper_sources src/st_adaptor.c)
+
+list(APPEND zookeeper_sources src/winport.c)
+
+add_library(zookeeper STATIC ${zookeeper_sources})
+target_link_libraries(zookeeper PUBLIC
+  hashtable
+  $<$<PLATFORM_ID:Linux>:rt> # clock_gettime
+  $<$<PLATFORM_ID:Windows>:ws2_32>) # Winsock 2.0
+
+# cli executable
+add_executable(cli src/cli.c)
+target_link_libraries(cli zookeeper)

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -83,8 +83,10 @@ function applyPatches() {
         shell.sed('-i', '#include "zookeeper.h"', '#include "winport.h"\n#include "zookeeper.h"\n', `${destination}/zk_adaptor.h`);
         shell.sed('-i', '#include "zk_adaptor.h"', '#include "zk_adaptor.h"\n#include "winport.h"\n', `${destination}/zookeeper.c`);
 
-        const cmakeFile = 'CMakeLists.txt';
-        shell.cp(`${env.rootFolder}/patches/${cmakeFile}`, `${env.sourceFolder}/src/c/${cmakeFile}`);
+        if (!process.env.ZK_INSTALL_VERBOSE) {
+            const cmakeFile = 'CMakeLists.txt';
+            shell.cp(`${env.rootFolder}/patches/${cmakeFile}`, `${env.sourceFolder}/src/c/${cmakeFile}`);
+        }
         return;
     }
 

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -83,6 +83,8 @@ function applyPatches() {
         shell.sed('-i', '#include "zookeeper.h"', '#include "winport.h"\n#include "zookeeper.h"\n', `${destination}/zk_adaptor.h`);
         shell.sed('-i', '#include "zk_adaptor.h"', '#include "zk_adaptor.h"\n#include "winport.h"\n', `${destination}/zookeeper.c`);
 
+        const cmakeFile = 'CMakeLists.txt';
+        shell.cp(`${env.rootFolder}/patches/${cmakeFile}`, `${env.sourceFolder}/src/c/${cmakeFile}`);
         return;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR will enable a quicker build experience for Windows users. It will bypass CMake feature checks and will also hide compiler warnings in the output, by overwriting the default `CMakeLists.txt`. 

There is an option to still use the default, by passing in the `ZK_INSTALL_VERBOSE` flag as described [here](https://github.com/yfinkelstein/node-zookeeper#development).

## Motivation and Context
To improve the developer experience on the Windows platform. 
Fixes issue #182 

## How Has This Been Tested?
Travis CI build passed (Windows, Linux, Mac OS X)
Manual `npm install` in a Windows 10 virtual machine.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/yfinkelstein/node-zookeeper/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/yfinkelstein/node-zookeeper/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly (if applicable).
