### PR TITLE
jsDoc type definitions

### DIFF
--- a/lib/typedefs.js
+++ b/lib/typedefs.js
@@ -23,8 +23,89 @@
  */
 
 /**
- * Children with stat
- * @typedef {Object} childrenWithStat
- * @property {Array.<string>} children
- * @property {stat} stat
+ * Mkdir callback
+ * @typedef {callback} mkdirCb
+ * @param {Error} error
+ * @param {boolean} [success]
+ */
+
+/**
+ * Connect callback
+ * @typedef {callback} connectCb
+ * @param {Error} error
+ * @param {ZooKeeper} client
+ */
+
+/**
+ * Path callback
+ * @typedef {callback} pathCb
+ * @param {number} rc
+ * @param {number} error
+ * @param {string} path
+ */
+
+/**
+ * Stat callback
+ * @typedef {callback} statCb
+ * @param {number} rc
+ * @param {number} error
+ * @param {stat} stat
+ */
+
+/**
+ * Data callback
+ * @typedef {callback} dataCb
+ * @param {number} rc
+ * @param {number} error
+ * @param {stat} stat
+ * @param {string|Buffer} data
+ */
+
+/**
+ * Child callback
+ * @typedef {callback} childCb
+ * @param {number} rc
+ * @param {number} error
+ * @param {Array.<string>} children
+ */
+
+/**
+ * Child2 callback
+ * @typedef {callback} child2Cb
+ * @param {number} rc
+ * @param {number} error
+ * @param {Array.<string>} children
+ * @param {stat} stat
+ */
+
+/**
+ * Value callback
+ * @typedef {callback} valueCb
+ * @param {number} rc
+ * @param {number} error
+ * @param {*} value
+ */
+
+/**
+ * Void callback
+ * @typedef {callback} voidCb
+ * @param {number} rc
+ * @param {number} error
+ */
+
+/**
+ * Watch callback
+ * @typedef {callback} watchCb
+ * @param {number} type
+ * @param {number} state
+ * @param {string} path
+ */
+
+/**
+ * ACL callback
+ * @typedef {callback} aclCb
+ * @param {number} rc
+ * @param {number} error
+ * @param {acl} acl
+ * @param {stat} stat
  */

--- a/lib/typedefs.js
+++ b/lib/typedefs.js
@@ -5,3 +5,26 @@
  * @property {string} scheme
  * @property {string} auth
  */
+
+/**
+ * stat
+ * @typedef {Object} stat
+ * @property {number} czxid
+ * @property {number} mzxid
+ * @property {number} ctime
+ * @property {number} mtime
+ * @property {number} version
+ * @property {number} cversion
+ * @property {number} aversion
+ * @property {string} ephemeralOwner
+ * @property {number} dataLength
+ * @property {number} numChildren
+ * @property {number} pzxid
+ */
+
+/**
+ * Children with stat
+ * @typedef {Object} childrenWithStat
+ * @property {Array.<string>} children
+ * @property {stat} stat
+ */

--- a/lib/zk_promise.js
+++ b/lib/zk_promise.js
@@ -21,7 +21,8 @@ class ZooKeeperPromise extends ZooKeeper {
      * @param path {string}
      * @param data {(string|Buffer)}
      * @param flags {number}
-     * @returns {ZkPromise}
+     * @fulfill {string}
+     * @returns {Promise.<string>}
      */
     create(path, data, flags) {
         return this.promisify(super.a_create, [path, data, flags]);
@@ -30,7 +31,8 @@ class ZooKeeperPromise extends ZooKeeper {
     /**
      * @param path {string}
      * @param watch {function}
-     * @returns {ZkPromise}
+     * @fulfill {stat}
+     * @returns {Promise.<stat>}
      */
     exists(path, watch) {
         return this.promisify(super.a_exists, [path, watch]);
@@ -39,7 +41,8 @@ class ZooKeeperPromise extends ZooKeeper {
     /**
      * @param path {string}
      * @param watchCb {function}
-     * @returns {ZkPromise}
+     * @fulfill {stat}
+     * @returns {Promise.<stat>}
      */
     w_exists(path, watchCb) {
         return this.promisify(super.aw_exists, [path, watchCb]);
@@ -48,7 +51,8 @@ class ZooKeeperPromise extends ZooKeeper {
     /**
      * @param path {string}
      * @param watch {boolean}
-     * @returns {ZkPromise}
+     * @fulfill {string|Buffer}
+     * @returns {Promise.<string|Buffer>}
      */
     get(path, watch) {
         return this.promisify(super.a_get, [path, watch]);
@@ -57,7 +61,8 @@ class ZooKeeperPromise extends ZooKeeper {
     /**
      * @param path {string}
      * @param watchCb {function}
-     * @returns {ZkPromise}
+     * @fulfill {string|Buffer}
+     * @returns {Promise.<string|Buffer>}
      */
     w_get(path, watchCb) {
         return this.promisify(super.aw_get, [path, watchCb]);
@@ -66,7 +71,8 @@ class ZooKeeperPromise extends ZooKeeper {
     /**
      * @param path {string}
      * @param watch {boolean}
-     * @returns {ZkPromise}
+     * @fulfill {Array.<string>}
+     * @returns {Promise.<Array.<string>>}
      */
     get_children(path, watch) {
         return this.promisify(super.a_get_children, [path, watch]);
@@ -75,7 +81,8 @@ class ZooKeeperPromise extends ZooKeeper {
     /**
      * @param path {string}
      * @param watchCb {function}
-     * @returns {ZkPromise}
+     * @fulfill {Array.<string>}
+     * @returns {Promise.<Array.<string>>}
      */
     w_get_children(path, watchCb) {
         return this.promisify(super.aw_get_children, [path, watchCb]);
@@ -84,7 +91,8 @@ class ZooKeeperPromise extends ZooKeeper {
     /**
      * @param path {string}
      * @param watch {boolean}
-     * @returns {ZkPromise}
+     * @fulfill {childrenWithStat}
+     * @returns {Promise.<childrenWithStat>}
      */
     get_children2(path, watch) {
         return this.promisify(super.a_get_children2, [path, watch]);
@@ -93,7 +101,8 @@ class ZooKeeperPromise extends ZooKeeper {
     /**
      * @param path {string}
      * @param watchCb {function}
-     * @returns {ZkPromise}
+     * @fulfill {childrenWithStat}
+     * @returns {Promise.<childrenWithStat>}
      */
     w_get_children2(path, watchCb) {
         return this.promisify(super.aw_get_children2, [path, watchCb]);
@@ -103,7 +112,8 @@ class ZooKeeperPromise extends ZooKeeper {
      * @param path {string}
      * @param data {(string|Buffer)}
      * @param version {number} an int32 value
-     * @returns {ZkPromise}
+     * @fulfill {stat}
+     * @returns {Promise.<stat>}
      */
     set(path, data, version) {
         return this.promisify(super.a_set, [path, data, version]);
@@ -112,7 +122,7 @@ class ZooKeeperPromise extends ZooKeeper {
     /**
      * @param path {string}
      * @param version {number} an int32 value
-     * @returns {ZkPromise}
+     * @returns {Promise}
      */
     // eslint-disable-next-line no-underscore-dangle
     delete_(path, version) {
@@ -122,7 +132,8 @@ class ZooKeeperPromise extends ZooKeeper {
 
     /**
      * @param path {string}
-     * @returns {ZkPromise}
+     * @fulfill {acl}
+     * @returns {Promise.<acl>}
      */
     get_acl(path) {
         return this.promisify(super.a_get_acl, [path]);
@@ -132,7 +143,7 @@ class ZooKeeperPromise extends ZooKeeper {
      * @param path {string}
      * @param version {number} an int32 value
      * @param acl {acl}
-     * @returns {ZkPromise}
+     * @returns {Promise}
      */
     set_acl(path, version, acl) {
         return this.promisify(super.a_set_acl, [path, version, acl]);
@@ -140,7 +151,7 @@ class ZooKeeperPromise extends ZooKeeper {
 
     /**
      * @param path {string}
-     * @returns {ZkPromise}
+     * @returns {Promise}
      */
     sync(path) {
         return this.promisify(super.a_sync, [path]);

--- a/lib/zk_promise.js
+++ b/lib/zk_promise.js
@@ -92,7 +92,7 @@ class ZooKeeperPromise extends ZooKeeper {
      * @param path {string}
      * @param watch {boolean}
      * @fulfill {childrenWithStat}
-     * @returns {Promise.<childrenWithStat>}
+     * @returns {Promise.<Array.<string>>,<stat>}
      */
     get_children2(path, watch) {
         return this.promisify(super.a_get_children2, [path, watch]);
@@ -102,7 +102,7 @@ class ZooKeeperPromise extends ZooKeeper {
      * @param path {string}
      * @param watchCb {function}
      * @fulfill {childrenWithStat}
-     * @returns {Promise.<childrenWithStat>}
+     * @returns {Promise.<Array.<string>>,<stat>}
      */
     w_get_children2(path, watchCb) {
         return this.promisify(super.aw_get_children2, [path, watchCb]);

--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -255,7 +255,7 @@ class ZooKeeper extends EventEmitter {
     /**
      * @param path {string}
      * @param watch {boolean}
-     * @param childCb {childCb}
+     * @param childCb {child2Cb}
      * @returns {*}
      */
     a_get_children2(path, watch, childCb) {
@@ -266,7 +266,7 @@ class ZooKeeper extends EventEmitter {
     /**
      * @param path {string}
      * @param watchCb {watchCb}
-     * @param childCb {childCb}
+     * @param childCb {child2Cb}
      * @returns {*}
      */
     aw_get_children2(path, watchCb, childCb) {

--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -43,7 +43,7 @@ const create = (con, p, cb) => {
  * does not support ./file or /dir/../file
  * @param con {ZooKeeper}
  * @param p {string}
- * @param callback {function}
+ * @param callback {mkdirCb}
  */
 const mkdirp = (con, p, callback) => {
     const dirs = normalize(p).split('/').slice(1); // remove empty string at the start.
@@ -130,7 +130,7 @@ class ZooKeeper extends EventEmitter {
 
     /**
      * @param options {object|function}
-     * @param cb {function}
+     * @param cb {connectCb}
      */
     connect(options, cb) {
         let callback;
@@ -168,7 +168,7 @@ class ZooKeeper extends EventEmitter {
      * @param path {string}
      * @param data {string|Buffer}
      * @param flags {number} an int32 value
-     * @param pathCb {function}
+     * @param pathCb {pathCb}
      * @returns {*}
      */
     a_create(path, data, flags, pathCb) {
@@ -179,7 +179,7 @@ class ZooKeeper extends EventEmitter {
     /**
      * @param path {string}
      * @param watch {boolean}
-     * @param statCb {function}
+     * @param statCb {statCb}
      * @returns {*}
      */
     a_exists(path, watch, statCb) {
@@ -189,8 +189,8 @@ class ZooKeeper extends EventEmitter {
 
     /**
      * @param path {string}
-     * @param watchCb {function}
-     * @param statCb {function}
+     * @param watchCb {watchCb}
+     * @param statCb {statCb}
      * @returns {*}
      */
     aw_exists(path, watchCb, statCb) {
@@ -201,7 +201,7 @@ class ZooKeeper extends EventEmitter {
     /**
      * @param path {string}
      * @param watch {bool}
-     * @param dataCb {function}
+     * @param dataCb {dataCb}
      * @returns {*}
      */
     a_get(path, watch, dataCb) {
@@ -216,8 +216,8 @@ class ZooKeeper extends EventEmitter {
 
     /**
      * @param path {string}
-     * @param watchCb {function}
-     * @param dataCb {function}
+     * @param watchCb {watchCb}
+     * @param dataCb {dataCb}
      * @returns {*}
      */
     aw_get(path, watchCb, dataCb) {
@@ -233,7 +233,7 @@ class ZooKeeper extends EventEmitter {
     /**
      * @param path {string}
      * @param watch {boolean}
-     * @param childCb {function}
+     * @param childCb {childCb}
      * @returns {*}
      */
     a_get_children(path, watch, childCb) {
@@ -243,8 +243,8 @@ class ZooKeeper extends EventEmitter {
 
     /**
      * @param path {string}
-     * @param watchCb {function}
-     * @param childCb {function}
+     * @param watchCb {watchCb}
+     * @param childCb {childCb}
      * @returns {*}
      */
     aw_get_children(path, watchCb, childCb) {
@@ -255,7 +255,7 @@ class ZooKeeper extends EventEmitter {
     /**
      * @param path {string}
      * @param watch {boolean}
-     * @param childCb {function}
+     * @param childCb {childCb}
      * @returns {*}
      */
     a_get_children2(path, watch, childCb) {
@@ -265,8 +265,8 @@ class ZooKeeper extends EventEmitter {
 
     /**
      * @param path {string}
-     * @param watchCb {function}
-     * @param childCb {function}
+     * @param watchCb {watchCb}
+     * @param childCb {childCb}
      * @returns {*}
      */
     aw_get_children2(path, watchCb, childCb) {
@@ -278,7 +278,7 @@ class ZooKeeper extends EventEmitter {
      * @param path {string}
      * @param data {string|Buffer}
      * @param version {number} an int32 value
-     * @param statCb {function}
+     * @param statCb {statCb}
      * @returns {*}
      */
     a_set(path, data, version, statCb) {
@@ -289,7 +289,7 @@ class ZooKeeper extends EventEmitter {
     /**
      * @param path {string}
      * @param version {number} an int32 value
-     * @param voidCb {function}
+     * @param voidCb {voidCb}
      * @returns {*}
      */
     // eslint-disable-next-line no-underscore-dangle
@@ -301,7 +301,7 @@ class ZooKeeper extends EventEmitter {
 
     /**
      * @param path {string}
-     * @param aclCb {function}
+     * @param aclCb {aclCb}
      * @returns {*}
      */
     a_get_acl(path, aclCb) {
@@ -313,7 +313,7 @@ class ZooKeeper extends EventEmitter {
      * @param path {string}
      * @param version {number} an int32 value
      * @param acl {acl}
-     * @param voidCb {function}
+     * @param voidCb {voidCb}
      * @returns {*}
      */
     a_set_acl(path, version, acl, voidCb) {
@@ -333,7 +333,7 @@ class ZooKeeper extends EventEmitter {
 
     /**
      * @param path {string}
-     * @param cb {function}
+     * @param cb {mkdirCb}
      */
     mkdirp(path, cb) {
         this.log(`Calling mkdirp with ${util.inspect([path, cb])}`);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The type definitions in this PR will help to make the developer experience better. When using an IDE or editor that can interpret the definitions, typing API calls will display expected params and data types. Also callback signatures and complex Promise resolution types! 

An example: hit CTRL + space in WebStorm to get the type information of an API method.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This will likely help developers understand the API a little better.
<!--- If it fixes an open issue, please link to the issue here. -->
Solves issue #195 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Travis CI Build passed
Created a new blank project with `npm init` and `npm install davidvujic/node-zookeeper#jsdoc_types`. Created a new JavaScript file with WebStorm that comsumes the library API.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/yfinkelstein/node-zookeeper/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/yfinkelstein/node-zookeeper/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
