### PR TITLE
Retry download if failed

### DIFF
--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -16,6 +16,7 @@ function retry(func, ...args) {
         return func(...args);
     } catch (e) {
         shell.echo(e.message);
+        shell.echo(`Retrying ${func.name}`);
         return func(...args);
     }
 }

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -11,14 +11,19 @@ function exec(action) {
     return res.stdout;
 }
 
-function retry(func, ...args) {
+async function retry(func, ...args) {
+    let res;
+
     try {
-        return func(...args);
+        res = await func(...args);
     } catch (e) {
         shell.echo(e.message);
         shell.echo(`Retrying ${func.name}`);
-        return func(...args);
+
+        res = func(...args);
     }
+
+    return res;
 }
 
 module.exports = {

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -11,6 +11,16 @@ function exec(action) {
     return res.stdout;
 }
 
+function retry(func, ...args) {
+    try {
+        return func(...args);
+    } catch (e) {
+        shell.echo(e.message);
+        return func(...args);
+    }
+}
+
 module.exports = {
     exec,
+    retry,
 };

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -20,7 +20,7 @@ async function retry(func, ...args) {
         shell.echo(e.message);
         shell.echo(`Retrying ${func.name}`);
 
-        res = func(...args);
+        res = await func(...args);
     }
 
     return res;

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -14,7 +14,12 @@ function writeFile(url, destination, resolve, reject) {
     });
 
     req.on('error', (e) => {
-        file.unlink(destination);
+        try {
+            file.unlink(destination);
+        } catch (err) {
+            shell.echo(err.message);
+        }
+
         reject(e);
     });
 

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -14,17 +14,12 @@ function writeFile(url, destination, resolve, reject) {
     });
 
     req.on('error', (e) => {
-        try {
-            file.unlink(destination);
-        } catch (err) {
-            shell.echo(err.message);
-        }
-
+        shell.rm(destination);
         reject(e);
     });
 
     file.on('error', () => {
-        file.unlink(destination);
+        shell.rm(destination);
         reject(new Error('File error'));
     });
 

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -4,7 +4,7 @@ const shell = require('shelljs');
 const decompress = require('decompress');
 const decompressTargz = require('decompress-targz');
 const env = require('./env.js');
-const { exec } = require('./helper.js');
+const { exec, retry } = require('./helper.js');
 
 function writeFile(url, destination, resolve, reject) {
     const file = fs.createWriteStream(destination);
@@ -120,7 +120,7 @@ if (env.isVerbose) {
 
 shell.cd(env.workFolder);
 
-download(env.downloadUrl, env.downloadedFileName)
+retry(download, env.downloadUrl, env.downloadedFileName)
     .then(() => {
         validateFile(env.downloadedFileName);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Occasionally, the download of the ZooKeeper source code fails due to timeout and probably more often if behind a proxy. Lately, failing downloads happen quite often in Travis CI. This PR includes a retry feature and extra checks on objects during download. If the download has failed, the install script will try once again.

The error:
```bash
file.unlink is not a function
Unable to download zookeeper library. Error: connect ETIMEDOUT <ip-address-masked>:80
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Solves failing `npm install`
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes issue #201 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Travis CI Build OK
`npm test`
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/yfinkelstein/node-zookeeper/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/yfinkelstein/node-zookeeper/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
