### PR TITLE
fix: handle multiple return values in promisified client

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,10 @@ Check out the code in the [examples](./examples) folder: master,workers, tasks a
 * `stat = await exists(path, watch)`
 * `data = await get(path, watch)`
 * `children = await get_children(path, watch)`
-* `{children, stat} = await get_children2( path, watch)`
+* `[children, stat] = await get_children2( path, watch)`
+    * return value types:
+        * children is an array of strings
+        * stat is an object
 * `stat = await set(path, data, version)`
 * `val = await sync(path)`
 * `delete_ (path, version)`
@@ -92,7 +95,10 @@ Check out the code in the [examples](./examples) folder: master,workers, tasks a
 * `stat = await w_exists(path, watch_cb)`
 * `data = await w_get(path, watch_cb)`
 * `children = await w_get_children(path, watch_cb)`
-* `{children, stat} = await w_get_children2 (path, watch_cb)`
+* `[children, stat] = await w_get_children2 (path, watch_cb)`
+    * return value types:
+        * children is an array of strings
+        * stat is an object
 
 ### Methods: callbacks based client ###
 

--- a/lib/zk_promise.js
+++ b/lib/zk_promise.js
@@ -92,8 +92,8 @@ class ZooKeeperPromise extends ZooKeeper {
     /**
      * @param path {string}
      * @param watch {boolean}
-     * @fulfill {Array.<string>>,<stat>}
-     * @returns {Promise.<Array.<string>>,<stat>}
+     * @fulfill {Array} [children, stat] - children: an array of strings, stat: object
+     * @returns {Promise.<Array>} [children, stat] - children: an array of strings, stat: object
      */
     get_children2(path, watch) {
         return this.promisify(super.a_get_children2, [path, watch]);
@@ -102,8 +102,8 @@ class ZooKeeperPromise extends ZooKeeper {
     /**
      * @param path {string}
      * @param watchCb {function}
-     * @fulfill {Array.<string>>,<stat>}
-     * @returns {Promise.<Array.<string>>,<stat>}
+     * @fulfill {Array} [children, stat] - children: an array of strings, stat: object
+     * @returns {Promise.<Array>} [children, stat] - children: an array of strings, stat: object
      */
     w_get_children2(path, watchCb) {
         return this.promisify(super.aw_get_children2, [path, watchCb]);
@@ -166,16 +166,12 @@ class ZooKeeperPromise extends ZooKeeper {
      */
     promisify(fn, args) {
         return new ZkPromise((resolve, reject) => {
-            const callback = (rc, error, result) => {
-                if (rc) {
-                    reject(rc);
-                } else if (args.length > 3) {
-                    // if there are multiple success values, we return an array
-                    Array.prototype.shift.call(args, 1);
-                    Array.prototype.shift.call(args, 1);
-                    resolve(args);
+            const callback = (rc, error, ...result) => {
+                if (rc !== 0) {
+                    reject(new Error(`${rc} ${error}`));
                 } else {
-                    resolve(result);
+                    const toReturn = result.length === 1 ? result[0] : result;
+                    resolve(toReturn);
                 }
             };
             fn.bind(this)(...args, callback);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
the `get_children2` and `w_get_children2` methods of the promisified zookeeper client should return both an array of children __and__ stats. The promisified version only returns the array.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This bug should be fixed, because of the new recommendation to use promises/async/await instead of callbacks.
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes issue #203 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Travis CI build OK.
`npm test`
`node examples/index.js`
~~TODO: run the "old" version (pre ES 201x) to verify the API/not working API.~~
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/yfinkelstein/node-zookeeper/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/yfinkelstein/node-zookeeper/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly (if applicable).
