### PR TITLE
Disable warnings as errors when compiling C and C++ code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,6 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
+    packages:
+      - gcc-9
+      - g++-9

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ os:
   - linux
   - osx
   - windows
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX=g++-4.8; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8"; fi
 install:
   - npm install
 script:
@@ -19,5 +16,3 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ os:
   - linux
   - osx
   - windows
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX=g++-9; f
 install:
   - npm install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ os:
   - osx
   - windows
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX=g++-9; f
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX=g++-9; fi
 install:
   - npm install
 script:

--- a/Dockerfile.gcc
+++ b/Dockerfile.gcc
@@ -1,0 +1,18 @@
+FROM gcc
+
+RUN gcc --version
+
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN apt-get install -y nodejs
+
+WORKDIR /app
+
+COPY . /app
+
+RUN rm -rf build
+RUN rm -rf node_modules
+RUN rm -f package-lock.json
+
+RUN npm install --unsafe-perm
+
+CMD ["node", "examples/index", "host.docker.internal:2181"]

--- a/binding.gyp
+++ b/binding.gyp
@@ -6,7 +6,7 @@
         "target_name": "zookeeper",
         'dependencies': ['libzk'],
         "sources": ["src/node-zk.cpp"],
-        'cflags': ['-Wall', '-O0'],
+        'cflags': ['-w', '-O0'],
         'conditions': [
             ['OS=="solaris"', {
                 'cflags': ['-Wno-strict-aliasing'],

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -34,7 +34,7 @@ if (env.isWindows) {
     exec(`cmake -DWANT_SYNCAPI=OFF -DCMAKE_GENERATOR_PLATFORM=${process.arch} .`);
     exec('cmake --build .');
 } else {
-    let configureCmd = './configure --without-syncapi --disable-shared --with-pic --without-cppunit';
+    let configureCmd = './configure CFLAGS="-Wno-error=format-overflow -w" --without-syncapi --disable-shared --with-pic --without-cppunit';
     let makeCmd = 'make';
     if (!process.env.ZK_INSTALL_VERBOSE) {
         configureCmd += ' --enable-silent-rules --quiet';

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -34,7 +34,7 @@ if (env.isWindows) {
     exec(`cmake -DWANT_SYNCAPI=OFF -DCMAKE_GENERATOR_PLATFORM=${process.arch} .`);
     exec('cmake --build .');
 } else {
-    let configureCmd = './configure CFLAGS="-Wno-error=format-overflow -w" --without-syncapi --disable-shared --with-pic --without-cppunit';
+    let configureCmd = './configure --without-syncapi --disable-shared --with-pic --without-cppunit';
     let makeCmd = 'make';
     if (!process.env.ZK_INSTALL_VERBOSE) {
         configureCmd += ' --enable-silent-rules --quiet';

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -34,7 +34,8 @@ if (env.isWindows) {
     exec(`cmake -DWANT_SYNCAPI=OFF -DCMAKE_GENERATOR_PLATFORM=${process.arch} .`);
     exec('cmake --build .');
 } else {
-    let configureCmd = './configure --without-syncapi --disable-shared --with-pic --without-cppunit';
+    const flags = '-w';
+    let configureCmd = `./configure CFLAGS='${flags}' --without-syncapi --disable-shared --with-pic --without-cppunit`;
     let makeCmd = 'make';
     if (!process.env.ZK_INSTALL_VERBOSE) {
         configureCmd += ' --enable-silent-rules --quiet';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Newer versions of gcc warns about code in the ZooKeeper C Client, and by default treat warnings as errors. This will break builds, unless passing a specific flag as described in issue #154 
Also, gcc 9 will warn about code existing in nan.h and v8.h. That is why warnings are disabled for the c++ wrapper code (in binding.gyp).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Users with the latest version of gcc will be able to run `npm install`.
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes issue #154 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Travis CI Build Ok
Build passed in a Dockerfile, using gcc 8.3.0 and 9
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/yfinkelstein/node-zookeeper/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/yfinkelstein/node-zookeeper/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly (if applicable).
