### PR TITLE
fix: less verbose Windows builds

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -31,13 +31,20 @@ shell.config.verbose = true;
 shell.cd(`${env.sourceFolder}`);
 
 if (env.isWindows) {
-    exec(`cmake -DWANT_SYNCAPI=OFF -DCMAKE_GENERATOR_PLATFORM=${process.arch} .`);
-    exec('cmake --build .');
+    let flags = '-DWANT_SYNCAPI=OFF ';
+    let output = '';
+
+    if (!env.isVerbose) {
+        flags = '';
+        output = ' > NUL';
+    }
+    exec(`cmake ${flags}-DCMAKE_GENERATOR_PLATFORM=${process.arch} .${output}`);
+    exec(`cmake --build .${output}`);
 } else {
     const flags = '-w';
     let configureCmd = `./configure CFLAGS='${flags}' --without-syncapi --disable-shared --with-pic --without-cppunit`;
     let makeCmd = 'make';
-    if (!process.env.ZK_INSTALL_VERBOSE) {
+    if (!env.isVerbose) {
         configureCmd += ' --enable-silent-rules --quiet';
         makeCmd += ' --no-print-directory --quiet';
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
By default, building on Windows will be less verbose. There's still a couple of warnings there, and should be fixed in a separate PR.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To increase the developer experience on Windows.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Travis CI Build OK
Ran `npm install` on a Windows 10 VM manually (both with and without the verbose flag set).
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/yfinkelstein/node-zookeeper/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/yfinkelstein/node-zookeeper/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly (if applicable).
