### PR TITLE
feat: empty-response event to handle no server responses

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,19 @@
 # Examples
 
+The `empty-response` event is used to handle server connecting problem, followed by infinite `no server responses`.
+
+```js
+  client.on('empty-response', (zk, counts) => {
+      if (counts <= 10) return;
+      client.close();
+  });
+```
+Param `counts` is the number of `no server responses` appears consecutively, normal server responses will reset it to 0.
+
+It should be noted that `empty-response` is not an offical zookeeper event.
+
+It should be noted that normal data fetching (getting node, getting children) will also followed by many `no server responses`, when the data is large enough. So please pick a safe counts.
+
 ## Run
 
 You can use `docker-compose` setup that is provided with the project. To run the tests simply run: `docker-compose run --build examples`.
@@ -24,6 +38,6 @@ Start and stop the example code a couple of times. Make sure the example code is
 
 ### Test: remote socket server sends no data
 
-This test is meant to verify that the `node-zk.cpp` wrapper will handle the scenario when a remote server return 0.
+This test is meant to verify that the `node-zk.cpp` wrapper will handle the scenario when a remote server return 0 too many times.
 
-The issue is described in [detail here](https://github.com/yfinkelstein/node-zookeeper/issues/172).
+The issue is described in [detail here](https://github.com/yfinkelstein/node-zookeeper/issues/172) and [here](https://github.com/yfinkelstein/node-zookeeper/issues/228).

--- a/examples/setup.js
+++ b/examples/setup.js
@@ -27,6 +27,10 @@ async function createNodes(paths) {
         createAllNodes(client, paths);
     });
 
+    client.on('empty-response', (zk, counts) => {
+        if (counts <= 10) return;
+        client.close();
+    });
     client.init({});
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Make an emtpy-response event to handle no server responses with a param named counts which is the number of `no server responses` appeared consecutively.

## Motivation and Context
fix #228 Handling ZNOTHING inside may not be a good idea

## How Has This Been Tested?
Changed and ran example.


