### PR TITLE
bump zookeeperVersion to 3.5.8

### DIFF
--- a/scripts/env.js
+++ b/scripts/env.js
@@ -34,10 +34,10 @@ if (isWindows) {
     downloadedFileName = `${downloadedFolderName}${suffix}`;
     sha512sum = `b2e03d95f8cf18b97a46e2f53871cef5a5da9d5d80b97009375aed7fb35368c440ca944c7e8b64efabbc065f6fb98bb86239f7c1491f0490efc71876d5a7f424  ${downloadedFileName}`;
 } else {
-    zookeeperVersion = '3.5.6';
+    zookeeperVersion = '3.5.8';
     downloadedFolderName = `apache-zookeeper-${zookeeperVersion}`;
     downloadedFileName = `${downloadedFolderName}${suffix}`;
-    sha512sum = `7f45817cbbc42aec5a7817fa2ae99656128e666dc58ace23d86bcfc5ca0dc49e418d1a7d1f082ad80ccb916f9f1b490167d16f836886af1a56fbcf720ad3b9d0  ${downloadedFileName}`;
+    sha512sum = `68d9894bf5cfd1eafeb6aa5b895aa2d125a501792f052fc0f6fe5f3bce81ec2e70a87a50a294101dc2e599d7ea4939ac0983179b8728e5fcc7cdde6bca02a006  ${downloadedFileName}`;
 }
 
 const variables = {


### PR DESCRIPTION
Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>

## Description
Update `zookeeperVersion` to 3.5.8.

## Motivation and Context
https://zookeeper.apache.org/doc/r3.5.8/releasenotes.html
https://downloads.apache.org/zookeeper/zookeeper-3.5.8/apache-zookeeper-3.5.8.tar.gz.sha512

```
This is a bugfix release for 3.5 branch.
It fixes 30 issues, including third party CVE fixes, several leader-election related fixes and a compatibility issue with applications built against earlier 3.5 client libraries (by restoring a few non public APIs).
```

## How Has This Been Tested?
```
$ ZK_INSTALL_VERBOSE=1 npm install

> zookeeper@4.5.2 install REDACTED/Github/node-zookeeper
> node ./scripts/prepublish.js && npm run build

cd REDACTED/Github/node-zookeeper/deps
exec command -v shasum >/dev/null 2>&1 && shasum -a 512 apache-zookeeper-3.5.8.tar.gz || sha512sum apache-zookeeper-3.5.8.tar.gz
68d9894bf5cfd1eafeb6aa5b895aa2d125a501792f052fc0f6fe5f3bce81ec2e70a87a50a294101dc2e599d7ea4939ac0983179b8728e5fcc7cdde6bca02a006  apache-zookeeper-3.5.8.tar.gz
test -d REDACTED/Github/node-zookeeper/deps/zookeeper
mv apache-zookeeper-3.5.8/zookeeper-client/zookeeper-client-c REDACTED/Github/node-zookeeper/deps/zookeeper
cp -R REDACTED/Github/node-zookeeper/patches/autoreconf/* REDACTED/Github/node-zookeeper/deps/zookeeper
rm -rf REDACTED/Github/node-zookeeper/patches/autoreconf

> zookeeper@4.5.2 build REDACTED/Github/node-zookeeper:
[...]
```

## Checklist:
- [X] I have read the [code of conduct](https://github.com/yfinkelstein/node-zookeeper/blob/master/CODE-OF-CONDUCT.md).
- [X] I have read the [contributing guide](https://github.com/yfinkelstein/node-zookeeper/blob/master/CONTRIBUTING.md).
- [] I have updated the documentation accordingly (if applicable).
