### PR TITLE
Dynamic Reconfiguration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 deps/zookeeper-client-c/
 .DS_Store
 package-lock.json
+.vscode

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Have a look at the code in the [examples](./examples) folder: with __master__, _
 * `val = await sync(path)`
 * `delete_ (path, version)`
   * (note the trailing `_`)
+* `config = getconfig(watch)`
+* `reconfig(joining, leaving, members, config_version)`
 * `set_acl(path, version, acl)`
 * `acl = await get_acl(path)`
 * `add_auth(scheme, auth)`
@@ -124,6 +126,7 @@ Have a look at the code in the [examples](./examples) folder: with __master__, _
     * return value types:
         * children is an array of strings
         * stat is an object
+* `config = w_getconfig(watch_cb)`
 
 ### Methods: callbacks based client methods
 
@@ -141,6 +144,8 @@ Have a look at the code in the [examples](./examples) folder: with __master__, _
 * `a_sync(path, value_cb)`
 * `a_delete_ (path, version, void_cb)`
   * (note the trailing `_`)
+* `a_getconfig(watch, data_cb)`
+* `a_reconfig(joining, leaving, members, version, data_cb)`  
 * `a_set_acl(path, version, acl, void_cb)`
 * `a_get_acl(path, acl_cb)`
 * `add_auth(scheme, auth, void_cb)`
@@ -151,6 +156,7 @@ Have a look at the code in the [examples](./examples) folder: with __master__, _
 * `aw_get(path, watch_cb, data_cb)`
 * `aw_get_children(path, watch_cb, child_cb)`
 * `aw_get_children2(path, watch_cb, child2_cb)`
+* `aw_getconfig(watch_cb, data_cb)`
 
 ### Callback Signatures
 
@@ -183,6 +189,10 @@ Have a look at the code in the [examples](./examples) folder: with __master__, _
 * watch : boolean
 * ttl: int32. TTL in milliseconds. Must be positive if any of the TTL modes is used; otherwise `undefined`.
 * scheme : authorisation scheme (digest, auth)
+* joining : string. Comma separated list of servers to be added. `null` for non-incremental reconfiguration.
+* leaving : string. Comma separated list of servers to be removed. `null` for non-incremental reconfiguration.
+* members : string. Comma separated list of new membership. `null` for incremental reconfiguration.
+* config_version : int64. `-1` to skip version checking
 * auth : authorisation credentials (username:password)
 * acl : acls list (same as output parameter, look below) - read only
 
@@ -309,3 +319,4 @@ with awesome contributions from:
 * Matt Lavin (mdlavin)
 * David Vujic (davidvujic)
 * Jakub Bieńkowski (jbienkowski311)
+* Brendan Hack (bhack-onshape)

--- a/lib/zk_promise.js
+++ b/lib/zk_promise.js
@@ -183,7 +183,6 @@ class ZooKeeperPromise extends ZooKeeper {
         return this.promisify(super.aw_getconfig, [watchCb]);
     }
 
-        
     /**
      * @param {string|null} joining
      * @param {string|null} leaving

--- a/lib/zk_promise.js
+++ b/lib/zk_promise.js
@@ -183,6 +183,18 @@ class ZooKeeperPromise extends ZooKeeper {
         return this.promisify(super.aw_getconfig, [watchCb]);
     }
 
+        
+    /**
+     * @param {string|null} joining
+     * @param {string|null} leaving
+     * @param {string|null} members
+     * @param {number} version
+     * @returns {*}
+     */
+    reconfig(joining, leaving, members, version) {
+        return this.promisify(super.a_reconfig, [joining, leaving, members, version]);
+    }
+
     /**
      * @private
      * @param {function} fn

--- a/lib/zk_promise.js
+++ b/lib/zk_promise.js
@@ -166,6 +166,24 @@ class ZooKeeperPromise extends ZooKeeper {
     }
 
     /**
+     * @param {boolean} watch
+     * @fulfill {string|Buffer}
+     * @returns {Promise.<string|Buffer>}
+     */
+    getconfig(watch) {
+        return this.promisify(super.a_getconfig, [watch]);
+    }
+
+    /**
+     * @param {function} watchCb
+     * @fulfill {string|Buffer}
+     * @returns {Promise.<string|Buffer>}
+     */
+    w_getconfig(watchCb) {
+        return this.promisify(super.aw_getconfig, [watchCb]);
+    }
+
+    /**
      * @private
      * @param {function} fn
      * @param {Array} args

--- a/lib/zk_promise.js
+++ b/lib/zk_promise.js
@@ -188,11 +188,11 @@ class ZooKeeperPromise extends ZooKeeper {
      * @param {string|null} joining
      * @param {string|null} leaving
      * @param {string|null} members
-     * @param {number} version
+     * @param {number} config_version
      * @returns {*}
      */
-    reconfig(joining, leaving, members, version) {
-        return this.promisify(super.a_reconfig, [joining, leaving, members, version]);
+    reconfig(joining, leaving, members, config_version) {
+        return this.promisify(super.a_reconfig, [joining, leaving, members, config_version]);
     }
 
     /**

--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -401,13 +401,13 @@ class ZooKeeper extends EventEmitter {
      * @param {string|null} joining
      * @param {string|null} leaving
      * @param {string|null} members
-     * @param {number} version
+     * @param {number} config_version
      * @param {dataCb} dataCb
      * @returns {*}
      */
-    a_reconfig(joining, leaving, members, version, dataCb) {
-        this.log(`Calling a_reconfig with ${util.inspect([joining, leaving, members, version, dataCb])}`);
-        return this.native.a_reconfig(joining, leaving, members, version, (rc, error, stat, data) => {
+    a_reconfig(joining, leaving, members, config_version, dataCb) {
+        this.log(`Calling a_reconfig with ${util.inspect([joining, leaving, members, config_version, dataCb])}`);
+        return this.native.a_reconfig(joining, leaving, members, config_version, (rc, error, stat, data) => {
             if (data && this.encoding) {
                 return dataCb(rc, error, stat, data.toString(this.encoding));
             }

--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -395,7 +395,25 @@ class ZooKeeper extends EventEmitter {
             }
             return dataCb(rc, error, stat, data);
         });
-    }    
+    }   
+    
+    /**
+     * @param {string|null} joining
+     * @param {string|null} leaving
+     * @param {string|null} members
+     * @param {number} version
+     * @param {dataCb} dataCb
+     * @returns {*}
+     */
+    a_reconfig(joining, leaving, members, version, dataCb) {
+        this.log(`Calling a_reconfig with ${util.inspect([joining, leaving, members, version, dataCb])}`);
+        return this.native.a_reconfig(joining, leaving, members, version, (rc, error, stat, data) => {
+            if (data && this.encoding) {
+                return dataCb(rc, error, stat, data.toString(this.encoding));
+            }
+            return dataCb(rc, error, stat, data);
+        });
+    }
 
     /**
      * @param {string} servers

--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -372,7 +372,7 @@ class ZooKeeper extends EventEmitter {
      * @param {dataCb} dataCb
      * @returns {*}
      */
-     a_getconfig(watch, dataCb) {
+    a_getconfig(watch, dataCb) {
         this.log(`Calling a_getconfig with ${util.inspect([watch, dataCb])}`);
         return this.native.a_getconfig(watch, (rc, error, stat, data) => {
             if (data && this.encoding) {
@@ -387,7 +387,7 @@ class ZooKeeper extends EventEmitter {
      * @param {dataCb} dataCb
      * @returns {*}
      */
-     aw_getconfig(watchCb, dataCb) {
+    aw_getconfig(watchCb, dataCb) {
         this.log(`Calling aw_getconfig with ${util.inspect([watchCb, dataCb])}`);
         return this.native.aw_getconfig(watchCb, (rc, error, stat, data) => {
             if (data && this.encoding) {
@@ -401,10 +401,10 @@ class ZooKeeper extends EventEmitter {
      * @param {string} servers
      * @returns {*}
      */
-     set_servers(servers) {
+    set_servers(servers) {
         this.log(`Calling set_servers with ${util.inspect([servers])}`);
         return this.native.set_servers(servers);
-     }
+    }
 
     get state() {
         return this.native.state;

--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -395,8 +395,8 @@ class ZooKeeper extends EventEmitter {
             }
             return dataCb(rc, error, stat, data);
         });
-    }   
-    
+    }
+
     /**
      * @param {string|null} joining
      * @param {string|null} leaving
@@ -406,13 +406,15 @@ class ZooKeeper extends EventEmitter {
      * @returns {*}
      */
     a_reconfig(joining, leaving, members, config_version, dataCb) {
-        this.log(`Calling a_reconfig with ${util.inspect([joining, leaving, members, config_version, dataCb])}`);
-        return this.native.a_reconfig(joining, leaving, members, config_version, (rc, error, stat, data) => {
-            if (data && this.encoding) {
-                return dataCb(rc, error, stat, data.toString(this.encoding));
-            }
-            return dataCb(rc, error, stat, data);
-        });
+        this.log('Calling a_reconfig with '
+                                + `${util.inspect([joining, leaving, members, config_version, dataCb])}`);
+        return this.native.a_reconfig(joining, leaving, members, config_version,
+            (rc, error, stat, data) => {
+                if (data && this.encoding) {
+                    return dataCb(rc, error, stat, data.toString(this.encoding));
+                }
+                return dataCb(rc, error, stat, data);
+            });
     }
 
     /**

--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -367,6 +367,45 @@ class ZooKeeper extends EventEmitter {
         return this.native.a_sync(path, cb);
     }
 
+    /**
+     * @param {boolean} watch
+     * @param {dataCb} dataCb
+     * @returns {*}
+     */
+     a_getconfig(watch, dataCb) {
+        this.log(`Calling a_getconfig with ${util.inspect([watch, dataCb])}`);
+        return this.native.a_getconfig(watch, (rc, error, stat, data) => {
+            if (data && this.encoding) {
+                return dataCb(rc, error, stat, data.toString(this.encoding));
+            }
+            return dataCb(rc, error, stat, data);
+        });
+    }
+
+    /**
+     * @param {watchCb} watchCb
+     * @param {dataCb} dataCb
+     * @returns {*}
+     */
+     aw_getconfig(watchCb, dataCb) {
+        this.log(`Calling aw_getconfig with ${util.inspect([watchCb, dataCb])}`);
+        return this.native.aw_getconfig(watchCb, (rc, error, stat, data) => {
+            if (data && this.encoding) {
+                return dataCb(rc, error, stat, data.toString(this.encoding));
+            }
+            return dataCb(rc, error, stat, data);
+        });
+    }    
+
+    /**
+     * @param {string} servers
+     * @returns {*}
+     */
+     set_servers(servers) {
+        this.log(`Calling set_servers with ${util.inspect([servers])}`);
+        return this.native.set_servers(servers);
+     }
+
     get state() {
         return this.native.state;
     }
@@ -692,6 +731,11 @@ class ZooKeeper extends EventEmitter {
     /** @deprecated @returns {number} 2 */
     static get ZOOKEEPER_READ() {
         return NativeZk.ZOOKEEPER_READ;
+    }
+
+    /** @deprecated @returns {string} "/zookeeper/config" */
+    static get ZOO_CONFIG_NODE() {
+        return NativeZk.ZOO_CONFIG_NODE;
     }
 
     /** @deprecated use strings directly */

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
         "Matt Lavin <matt.lavin@gmail.com>",
         "Roy Cheng <roy.b.cheng@newegg.com>",
         "David Vujic (https://github.com/DavidVujic)",
-        "Jakub Bienkowski (https://github.com/jbienkowski311)"
+        "Jakub Bienkowski (https://github.com/jbienkowski311)",
+        "Brendan Hack (bhack@ptc.com)"
     ],
     "repository": {
         "type": "git",

--- a/src/converters.hpp
+++ b/src/converters.hpp
@@ -19,6 +19,12 @@ namespace nodezk {
         return val;
     }
 
+    int64_t toInt64(Local<Value> val_local) {
+        int64_t val = static_cast<int64_t>(val_local->NumberValue(Nan::GetCurrentContext()).FromJust());
+
+        return val;
+    }
+
     int32_t toInt(Local<Object> arg, Local<String> propertyName) {
         Local<Value> val_local = toLocalVal(arg, propertyName);
 

--- a/src/node-zk.cpp
+++ b/src/node-zk.cpp
@@ -144,6 +144,7 @@ public:
         Nan::SetPrototypeMethod(constructor_template,  "a_getconfig",  AGetConfig);
         Nan::SetPrototypeMethod(constructor_template,  "aw_getconfig",  AWGetConfig);
         Nan::SetPrototypeMethod(constructor_template,  "set_servers",  SetServers);
+        Nan::SetPrototypeMethod(constructor_template,  "a_reconfig",  AReconfig);
 
         //what's the advantage of using constructor_template->PrototypeTemplate()->SetAccessor ?
         Nan::SetAccessor(constructor_template->InstanceTemplate(), LOCAL_STRING("state"), StatePropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
@@ -931,6 +932,20 @@ public:
         Nan::Utf8String _servers (toString(info[0]));
 
         METHOD_EPILOG(zoo_set_servers(zk->zhandle, *_servers));
+    }
+
+    static void AReconfig(const Nan::FunctionCallbackInfo<Value>& info) {
+        A_METHOD_PROLOG(5);
+
+        Nan::Utf8String _joining (toString(info[0]));
+        Nan::Utf8String _leaving (toString(info[1]));
+        Nan::Utf8String _members (toString(info[2]));
+        int64_t _version = toInt64(info[3]);
+        
+        METHOD_EPILOG(zoo_areconfig(zk->zhandle,
+                        info[0]->IsNullOrUndefined() ? NULL : *_joining,
+                        info[1]->IsNullOrUndefined() ? NULL : *_leaving,
+                        info[2]->IsNullOrUndefined() ? NULL : *_members, _version, &data_completion, cb));
     }
 
     static void AddAuth(const Nan::FunctionCallbackInfo<Value>& info) {

--- a/src/node-zk.cpp
+++ b/src/node-zk.cpp
@@ -141,6 +141,9 @@ public:
         Nan::SetPrototypeMethod(constructor_template,  "a_set_acl",  ASetAcl);
         Nan::SetPrototypeMethod(constructor_template,  "add_auth",  AddAuth);
         Nan::SetPrototypeMethod(constructor_template,  "a_sync",  ASync);
+        Nan::SetPrototypeMethod(constructor_template,  "a_getconfig",  AGetConfig);
+        Nan::SetPrototypeMethod(constructor_template,  "aw_getconfig",  AWGetConfig);
+        Nan::SetPrototypeMethod(constructor_template,  "set_servers",  SetServers);
 
         //what's the advantage of using constructor_template->PrototypeTemplate()->SetAccessor ?
         Nan::SetAccessor(constructor_template->InstanceTemplate(), LOCAL_STRING("state"), StatePropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
@@ -218,6 +221,7 @@ public:
         NODE_DEFINE_CONSTANT(constructor, ZOO_ASSOCIATING_STATE);
         NODE_DEFINE_CONSTANT(constructor, ZOO_CONNECTED_STATE);
 
+        Nan::DefineOwnProperty(constructor, LOCAL_STRING("ZOO_CONFIG_NODE"), LOCAL_STRING(ZOO_CONFIG_NODE), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
 
         NODE_DEFINE_CONSTANT(constructor, ZOK);
 
@@ -903,6 +907,30 @@ public:
         Nan::Utf8String _path (toString(info[0]));
 
         METHOD_EPILOG(zoo_async(zk->zhandle, *_path, &string_completion, cb));
+    }
+
+    static void AGetConfig(const Nan::FunctionCallbackInfo<Value>& info) {
+        A_METHOD_PROLOG(2);
+
+        bool watch = toBool(info[0]);
+
+        METHOD_EPILOG(zoo_agetconfig(zk->zhandle, watch, &data_completion, cb));
+    }
+
+    static void AWGetConfig(const Nan::FunctionCallbackInfo<Value>& info) {
+        AW_METHOD_PROLOG(2);
+
+        METHOD_EPILOG(zoo_awgetconfig(zk->zhandle, &watcher_fn, cbw, &data_completion, cb));
+    }
+    
+    static void SetServers(const Nan::FunctionCallbackInfo<Value>& info) {
+        ZooKeeper *zk = ObjectWrap::Unwrap<ZooKeeper>(info.This());
+        assert(zk);
+        THROW_IF_NOT (info.Length() >= 1, "expected at least 1 arguments") 
+
+        Nan::Utf8String _servers (toString(info[0]));
+
+        METHOD_EPILOG(zoo_set_servers(zk->zhandle, *_servers));
     }
 
     static void AddAuth(const Nan::FunctionCallbackInfo<Value>& info) {


### PR DESCRIPTION
Exposes the dynamic reconfiguration methods from the core ZooKeeper API to the top level JavaScript ZooKeeper class.

## Description
Exposes the following methods to the ZooKeeper class as both async and callback funtions:

`zoo_agetconfig`
`zoo_awgetconfig`
`zoo_areconfig`

The following only has one variant as it's a syncronous function
`zoo_setservers`

Also expose the `ZOO_CONFIG_NODE` constant

These allow the user to implement client side dynamic reconfiguration support.

## Motivation and Context
Adds Dynamic Reconfiguration support to the client
https://github.com/yfinkelstein/node-zookeeper/issues/208

## How Has This Been Tested?
Tested in an external command line ZooKeeper client application that uses this module and implements a full client Dynamic Reconfiguration workflow. Also tested unauthenticated reconfiguration from the same client app.

Implementation is a straight line from the C API to top level JavaScript functions with no interaction with other parts of the codebase.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ x] I have read the [code of conduct](https://github.com/yfinkelstein/node-zookeeper/blob/master/CODE-OF-CONDUCT.md).
- [ x] I have read the [contributing guide](https://github.com/yfinkelstein/node-zookeeper/blob/master/CONTRIBUTING.md).
- [ x] I have updated the documentation accordingly (if applicable).
