### PR TITLE
ability to overwrite default response counter limit (10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Have a look at the code in the [examples](./examples) folder: with __master__, _
 
 ### Input Parameters
 
-* options : object. valid keys: { connect, timeout, debug_level, host_order_deterministic, data_as_buffer}
+* options : object. valid keys: { connect, timeout, debug_level, host_order_deterministic, data_as_buffer, response_counter_limit }
 * path : string
 * data : string or Buffer
 * flags : int32. Supported:

--- a/src/node-zk.cpp
+++ b/src/node-zk.cpp
@@ -114,6 +114,8 @@ struct completion_data {
     void *data;
 };
 
+int32_t RESPONSE_COUNTER_LIMIT = 10;
+
 class ZooKeeper: public Nan::ObjectWrap {
 public:
     static void Initialize (Local<Object> target) {
@@ -369,7 +371,7 @@ public:
             LOG_ERROR("yield:zookeeper_process returned an error: %d - %s\n", rc, zerror(rc));
         }
 
-        if (zk->noResponseCounter > 10) {
+        if (zk->noResponseCounter > RESPONSE_COUNTER_LIMIT) {
             LOG_ERROR("yield:zookeeper_process returned no response too many times: %d\n", zk->noResponseCounter);
             zk->realClose(ZOO_EXPIRED_SESSION_STATE);
             return;
@@ -445,6 +447,11 @@ public:
         int32_t session_timeout = toInt(arg, LOCAL_STRING("timeout"));
         if (session_timeout == 0) {
             session_timeout = 20000;
+        }
+
+        int32_t response_counter_limit = toInt(arg, LOCAL_STRING("response_counter_limit"));
+        if (response_counter_limit > 0) {
+            RESPONSE_COUNTER_LIMIT = response_counter_limit;
         }
 
         clientid_t local_client;


### PR DESCRIPTION
## Description
Library returns error "zookeeper_process returned no response too many times: 11".
We wanted to add a flag using which will be possible to overwrite the default response counter limit (10).

## Motivation and Context
We have nodes in ZK with a lot of data and the server responds after a couple more tries than 10, about ~40.

## How Has This Been Tested?
Changed value of a new flag "response_counter_limit" to "100" and data was received.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have read the [code of conduct](https://github.com/yfinkelstein/node-zookeeper/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/yfinkelstein/node-zookeeper/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly (if applicable).