### PR TITLE
fix: solve npm audit issues by replacing tape and tap-spec with Ava

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,4 +7,4 @@ Fork this repo, write code and send a pull request. Easy!
 * If possible, isolate the changes in the branch to the feature only. Merges will be easier if general refactorings, that are not specific to the feature, are made in separate branches.
 * If possible, avoid general dependency updates in the feature branch.
 * If possible, send pull requests early. Don't wait too long, even if the feature is not completely done. The new code can very likely be merged without causing any problems (if the code changes are not of type breaking features). Think of it as "silent releases".
-* If you think it is relevant and add value: write unit test(s). Use the`tape` unit test library. They could also be valuable as description of features.
+* If you think it is relevant and add value: write unit test(s). Use the`ava` unit test library. They could also be valuable as description of features.

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     },
     "devDependencies": {
         "@types/node": "^14.14.6",
+        "ava": "^3.15.0",
         "eslint": "7.x",
         "eslint-config-airbnb-base": "14.x",
         "eslint-plugin-import": "2.x",
@@ -47,8 +48,6 @@
         "prebuildify": "^4.1.1",
         "proxyquire": "2.x",
         "sinon": "9.x",
-        "tap-spec": "5.x",
-        "tape": "5.x",
         "typescript": "^4.0.5",
         "webworker": "0.x"
     },
@@ -59,9 +58,9 @@
         "install": "node ./scripts/prepublish.js && npm run build",
         "lint": "eslint .",
         "test": "npm run lint && npm run test-unit",
-        "test-components": "npm run build-components && tape ./tests/components/**/*.js | tap-spec",
+        "test-components": "npm run build-components && ava ./tests/components/**/*.js",
         "test-integration": "node ./tests/integration/index",
-        "test-unit": "tape ./tests/unit/**/*.js | tap-spec",
+        "test-unit": "ava ./tests/unit/**/*.js",
         "type-declarations": "tsc --outFile ./lib/typedeclarations.d.ts"
     },
     "engines": {

--- a/tests/components/converterstest.js
+++ b/tests/components/converterstest.js
@@ -1,4 +1,4 @@
-const test = require('tape');
+const test = require('ava');
 const converters = require('./build/Release/converters.node');
 
 test('Integer is converted to string', (t) => {
@@ -6,8 +6,8 @@ test('Integer is converted to string', (t) => {
     const expected = 4711;
     const res = converters.toStrTest(expected);
 
-    t.deepEquals(res, `${expected}`);
-    t.deepEquals(typeof res, typeof '');
+    t.deepEqual(res, `${expected}`);
+    t.deepEqual(typeof res, typeof '');
 });
 
 test('Unix time is converted to date', (t) => {
@@ -23,7 +23,7 @@ test('Unix time is converted to date', (t) => {
     const r = new Date(converted * 1000);
     const res = `${r.getFullYear()}-${r.getMonth()}-${r.getDate()}}`;
 
-    t.deepEquals(res, expected);
+    t.deepEqual(res, expected);
 });
 
 test('Object value is converted to bool', (t) => {
@@ -31,8 +31,8 @@ test('Object value is converted to bool', (t) => {
     const expected = true;
     const res = converters.toBoolTest({ val: 'true' });
 
-    t.deepEquals(res, expected);
-    t.deepEquals(typeof res, typeof true);
+    t.deepEqual(res, expected);
+    t.deepEqual(typeof res, typeof true);
 });
 
 test('Object value is converted to integer', (t) => {
@@ -42,8 +42,8 @@ test('Object value is converted to integer', (t) => {
     const res = converters.toIntTest({ val: '4711' });
     const resNeg = converters.toIntTest({ val: '-1' });
 
-    t.deepEquals(res, expected);
-    t.deepEquals(resNeg, expectedNeg);
+    t.deepEqual(res, expected);
+    t.deepEqual(resNeg, expectedNeg);
 });
 
 test('Object value is converted to unsigned integer', (t) => {
@@ -51,5 +51,5 @@ test('Object value is converted to unsigned integer', (t) => {
     const expected = 4711;
     const res = converters.toUintTest('4711');
 
-    t.deepEquals(res, expected);
+    t.deepEqual(res, expected);
 });

--- a/tests/unit/index/apitest.js
+++ b/tests/unit/index/apitest.js
@@ -1,39 +1,39 @@
 const { EventEmitter } = require('events');
-const test = require('tape');
+const test = require('ava');
 const ZooKeeper = require('../../../lib/index');
 
 function assertPublicApi(zk, t) {
     t.plan(26);
 
-    t.equal(typeof zk.a_create, 'function');
-    t.equal(typeof zk.a_createTtl, 'function');
-    t.equal(typeof zk.a_exists, 'function');
-    t.equal(typeof zk.a_get, 'function');
-    t.equal(typeof zk.a_get_acl, 'function');
-    t.equal(typeof zk.a_get_children, 'function');
+    t.is(typeof zk.a_create, 'function');
+    t.is(typeof zk.a_createTtl, 'function');
+    t.is(typeof zk.a_exists, 'function');
+    t.is(typeof zk.a_get, 'function');
+    t.is(typeof zk.a_get_acl, 'function');
+    t.is(typeof zk.a_get_children, 'function');
 
-    t.equal(typeof zk.a_get_children2, 'function');
-    t.equal(typeof zk.a_set, 'function');
-    t.equal(typeof zk.a_set_acl, 'function');
-    t.equal(typeof zk.a_sync, 'function');
-    t.equal(typeof zk.add_auth, 'function');
+    t.is(typeof zk.a_get_children2, 'function');
+    t.is(typeof zk.a_set, 'function');
+    t.is(typeof zk.a_set_acl, 'function');
+    t.is(typeof zk.a_sync, 'function');
+    t.is(typeof zk.add_auth, 'function');
 
-    t.equal(typeof zk.aw_exists, 'function');
-    t.equal(typeof zk.aw_get, 'function');
-    t.equal(typeof zk.aw_get_children, 'function');
-    t.equal(typeof zk.aw_get_children2, 'function');
-    t.equal(typeof zk.close, 'function');
+    t.is(typeof zk.aw_exists, 'function');
+    t.is(typeof zk.aw_get, 'function');
+    t.is(typeof zk.aw_get_children, 'function');
+    t.is(typeof zk.aw_get_children2, 'function');
+    t.is(typeof zk.close, 'function');
 
-    t.equal(zk.config, undefined);
-    t.equal(typeof zk.connect, 'function');
-    t.equal(zk.data_as_buffer, true);
-    t.equal(zk.encoding, null);
-    t.equal(typeof zk.init, 'function');
+    t.is(zk.config, undefined);
+    t.is(typeof zk.connect, 'function');
+    t.is(zk.data_as_buffer, true);
+    t.is(zk.encoding, null);
+    t.is(typeof zk.init, 'function');
 
-    t.equal(zk.logger, undefined);
-    t.equal(typeof zk.mkdirp, 'function');
-    t.equal(typeof zk.setEncoding, 'function');
-    t.equal(typeof zk.setLogger, 'function');
+    t.is(zk.logger, undefined);
+    t.is(typeof zk.mkdirp, 'function');
+    t.is(typeof zk.setEncoding, 'function');
+    t.is(typeof zk.setLogger, 'function');
 
     t.true(zk instanceof EventEmitter);
 }

--- a/tests/unit/index/configtest.js
+++ b/tests/unit/index/configtest.js
@@ -1,4 +1,4 @@
-const test = require('tape');
+const test = require('ava');
 const ZooKeeper = require('../../../lib/index');
 
 test('inject config', (t) => {
@@ -8,7 +8,7 @@ test('inject config', (t) => {
 
     const zk = new ZooKeeper({ connect: expected });
 
-    t.equal(zk.config.connect, expected);
+    t.is(zk.config.connect, expected);
 });
 
 test('inject connection config as a string', (t) => {
@@ -18,6 +18,6 @@ test('inject connection config as a string', (t) => {
 
     const zk = new ZooKeeper(expected);
 
-    t.equal(zk.config.connect, expected);
-    t.equal(Object.keys(zk.config).length, 1);
+    t.is(zk.config.connect, expected);
+    t.is(Object.keys(zk.config).length, 1);
 });

--- a/tests/unit/index/encodingtest.js
+++ b/tests/unit/index/encodingtest.js
@@ -1,4 +1,4 @@
-const test = require('tape');
+const test = require('ava');
 const ZooKeeper = require('../../../lib/index');
 
 test('inject encoding will set data as buffer to false', (t) => {
@@ -9,6 +9,6 @@ test('inject encoding will set data as buffer to false', (t) => {
     const zk = new ZooKeeper();
     zk.setEncoding(expected);
 
-    t.equal(zk.encoding, expected);
-    t.equal(zk.data_as_buffer, false);
+    t.is(zk.encoding, expected);
+    t.is(zk.data_as_buffer, false);
 });

--- a/tests/unit/index/loggertest.js
+++ b/tests/unit/index/loggertest.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-const test = require('tape');
+const test = require('ava');
 const ZooKeeper = require('../../../lib/index');
 
 test('Inject custom logger', (t) => {
@@ -8,7 +8,7 @@ test('Inject custom logger', (t) => {
     const zk = new ZooKeeper();
     zk.setLogger(console.log);
 
-    t.equal(zk.logger, console.log);
+    t.is(zk.logger, console.log);
 });
 
 test('Use default logger', (t) => {
@@ -17,7 +17,7 @@ test('Use default logger', (t) => {
     const zk = new ZooKeeper();
     zk.setLogger(true);
 
-    t.equal(typeof zk.logger, 'function');
+    t.is(typeof zk.logger, 'function');
 });
 
 test('Explicit set use no logger', (t) => {
@@ -26,5 +26,5 @@ test('Explicit set use no logger', (t) => {
     const zk = new ZooKeeper();
     zk.setLogger(false);
 
-    t.equal(zk.logger, undefined);
+    t.is(zk.logger, undefined);
 });

--- a/tests/unit/util/helpertest.js
+++ b/tests/unit/util/helpertest.js
@@ -1,5 +1,5 @@
 const sinon = require('sinon');
-const test = require('tape');
+const test = require('ava');
 const { deprecationLog } = require('../../../lib/helper');
 
 class Test {
@@ -14,9 +14,9 @@ test('deprecation log is called with proper arguments', (t) => {
 
     deprecationLogStub(Test.name, 'method');
 
-    t.equal(deprecationLogStub.callCount, 1);
-    t.equal(deprecationLogStub.getCall(0).args[0], 'Test');
-    t.equal(deprecationLogStub.getCall(0).args[1], 'method');
+    t.is(deprecationLogStub.callCount, 1);
+    t.is(deprecationLogStub.getCall(0).args[0], 'Test');
+    t.is(deprecationLogStub.getCall(0).args[1], 'method');
 });
 
 test('deprecation log gives proper message', (t) => {
@@ -25,8 +25,8 @@ test('deprecation log gives proper message', (t) => {
 
     Test.method();
 
-    t.equal(consoleStub.callCount, 1);
-    t.equal(consoleStub.getCall(0).args[0], 'ZOOKEEPER LOG: Test::method is being deprecated!');
+    t.is(consoleStub.callCount, 1);
+    t.is(consoleStub.getCall(0).args[0], 'ZOOKEEPER LOG: Test::method is being deprecated!');
 
     consoleStub.restore();
 });

--- a/tests/unit/util/promisetest.js
+++ b/tests/unit/util/promisetest.js
@@ -1,5 +1,5 @@
 const sinon = require('sinon');
-const test = require('tape');
+const test = require('ava');
 
 const ZkPromise = require('../../../lib/promise');
 
@@ -11,8 +11,8 @@ test('ZkPromise get', (t) => {
         property: expected,
     });
 
-    promise.get('property').then((actual) => {
-        t.equal(actual, expected);
+    return promise.get('property').then((actual) => {
+        t.is(actual, expected);
     });
 });
 
@@ -22,8 +22,8 @@ test('ZkPromise put', (t) => {
     const expected = 'value';
     const promise = ZkPromise.resolve({});
 
-    promise.put('property', expected).then((actual) => {
-        t.equal(actual, expected);
+    return promise.put('property', expected).then((actual) => {
+        t.is(actual, expected);
     });
 });
 
@@ -34,8 +34,8 @@ test('ZkPromise call', (t) => {
         multiply: (a, b) => a * b,
     });
 
-    promise.call('multiply', 2, 3).then((actual) => {
-        t.equal(actual, 2 * 3);
+    return promise.call('multiply', 2, 3).then((actual) => {
+        t.is(actual, 2 * 3);
     });
 });
 
@@ -45,10 +45,10 @@ test('ZkPromise addCallback', (t) => {
     const callback = sinon.stub().callsFake((value) => value * 2);
     const promise = ZkPromise.resolve(10);
 
-    promise.addCallback(callback).then((actual) => {
-        t.equal(actual, 20);
-        t.equal(callback.callCount, 1);
-        t.equal(callback.getCall(0).args[0], 10);
+    return promise.addCallback(callback).then((actual) => {
+        t.is(actual, 20);
+        t.is(callback.callCount, 1);
+        t.is(callback.getCall(0).args[0], 10);
     });
 });
 
@@ -58,10 +58,10 @@ test('ZkPromise addErrback', (t) => {
     const callback = sinon.stub().callsFake((value) => value * 2);
     const promise = ZkPromise.reject(10);
 
-    promise.addErrback(callback).then((actual) => {
-        t.equal(actual, 20);
-        t.equal(callback.callCount, 1);
-        t.equal(callback.getCall(0).args[0], 10);
+    return promise.addErrback(callback).then((actual) => {
+        t.is(actual, 20);
+        t.is(callback.callCount, 1);
+        t.is(callback.getCall(0).args[0], 10);
     });
 });
 
@@ -75,18 +75,18 @@ test('ZkPromise addBoth', (t) => {
     // eslint-disable-next-line max-len
     const promise = (succeeds) => new ZkPromise((resolve, reject) => (succeeds ? resolve(10) : reject(10)));
 
-    promise(true).addBoth(callback)
+    return promise(true).addBoth(callback)
         .then((actual) => {
-            t.equal(actual, 20);
-            t.equal(callback.callCount, 1);
-            t.equal(callback.getCall(0).args[0], 10);
+            t.is(actual, 20);
+            t.is(callback.callCount, 1);
+            t.is(callback.getCall(0).args[0], 10);
             return promise(false).addBoth(errback);
         })
         .catch((actual) => {
             t.true(actual instanceof Error);
-            t.equal(actual.message, 'errback!');
-            t.equal(errback.callCount, 1);
-            t.equal(errback.getCall(0).args[0], 10);
+            t.is(actual.message, 'errback!');
+            t.is(errback.callCount, 1);
+            t.is(errback.getCall(0).args[0], 10);
         });
 });
 
@@ -100,21 +100,21 @@ test('ZkPromise addCallbacks', (t) => {
     // eslint-disable-next-line max-len
     const promise = (succeeds) => new ZkPromise((resolve, reject) => (succeeds ? resolve(10) : reject(10)));
 
-    promise(true).addCallbacks(callback, errback)
+    return promise(true).addCallbacks(callback, errback)
         .then((actual) => {
-            t.equal(actual, 20);
-            t.equal(callback.callCount, 1);
-            t.equal(callback.getCall(0).args[0], 10);
-            t.equal(errback.callCount, 0);
+            t.is(actual, 20);
+            t.is(callback.callCount, 1);
+            t.is(callback.getCall(0).args[0], 10);
+            t.is(errback.callCount, 0);
             callback.resetHistory();
             errback.resetHistory();
             return promise(false).addCallbacks(callback, errback);
         })
         .catch((actual) => {
             t.true(actual instanceof Error);
-            t.equal(actual.message, 'errback!');
-            t.equal(callback.callCount, 0);
-            t.equal(errback.callCount, 1);
-            t.equal(errback.getCall(0).args[0], 10);
+            t.is(actual.message, 'errback!');
+            t.is(callback.callCount, 0);
+            t.is(errback.callCount, 1);
+            t.is(errback.getCall(0).args[0], 10);
         });
 });

--- a/tests/unit/zookeeper/exportedconstantstest.js
+++ b/tests/unit/zookeeper/exportedconstantstest.js
@@ -1,4 +1,4 @@
-const test = require('tape');
+const test = require('ava');
 const { join } = require('path');
 const NativeZk = require('node-gyp-build')(join(__dirname, '../../../')).ZooKeeper;
 const constants = require('../../../lib/constants');
@@ -10,34 +10,34 @@ test('native static constants are exported', (t) => {
     t.plan(keys.length);
 
     keys.forEach((key) => {
-        t.equal(constants[key], NativeZk[key]);
+        t.is(constants[key], NativeZk[key]);
     });
 });
 
 test('deprecated legacy event constants are exported', (t) => {
     t.plan(8);
 
-    t.equal(ZooKeeper.on_closed, 'close');
-    t.equal(ZooKeeper.on_connected, 'connect');
-    t.equal(ZooKeeper.on_connecting, 'connecting');
-    t.equal(ZooKeeper.on_event_created, 'created');
+    t.is(ZooKeeper.on_closed, 'close');
+    t.is(ZooKeeper.on_connected, 'connect');
+    t.is(ZooKeeper.on_connecting, 'connecting');
+    t.is(ZooKeeper.on_event_created, 'created');
 
-    t.equal(ZooKeeper.on_event_deleted, 'deleted');
-    t.equal(ZooKeeper.on_event_changed, 'changed');
-    t.equal(ZooKeeper.on_event_child, 'child');
-    t.equal(ZooKeeper.on_event_notwatching, 'notwatching');
+    t.is(ZooKeeper.on_event_deleted, 'deleted');
+    t.is(ZooKeeper.on_event_changed, 'changed');
+    t.is(ZooKeeper.on_event_child, 'child');
+    t.is(ZooKeeper.on_event_notwatching, 'notwatching');
 });
 
 test('legacy event constants are exported', (t) => {
     t.plan(8);
 
-    t.equal(constants.on_closed, 'close');
-    t.equal(constants.on_connected, 'connect');
-    t.equal(constants.on_connecting, 'connecting');
-    t.equal(constants.on_event_created, 'created');
+    t.is(constants.on_closed, 'close');
+    t.is(constants.on_connected, 'connect');
+    t.is(constants.on_connecting, 'connecting');
+    t.is(constants.on_event_created, 'created');
 
-    t.equal(constants.on_event_deleted, 'deleted');
-    t.equal(constants.on_event_changed, 'changed');
-    t.equal(constants.on_event_child, 'child');
-    t.equal(constants.on_event_notwatching, 'notwatching');
+    t.is(constants.on_event_deleted, 'deleted');
+    t.is(constants.on_event_changed, 'changed');
+    t.is(constants.on_event_child, 'child');
+    t.is(constants.on_event_notwatching, 'notwatching');
 });

--- a/tests/unit/zookeeper/nativeobjecttest.js
+++ b/tests/unit/zookeeper/nativeobjecttest.js
@@ -1,4 +1,4 @@
-const test = require('tape');
+const test = require('ava');
 const { join } = require('path');
 const NativeZk = require('node-gyp-build')(join(__dirname, '../../../')).ZooKeeper;
 const ZooKeeper = require('../../../lib/zookeeper');
@@ -16,17 +16,16 @@ test('native object is extended with an emit function', (t) => {
 
     const zk = new ZooKeeper({});
 
-    t.equal(typeof zk.native.emit, 'function');
+    t.is(typeof zk.native.emit, 'function');
 });
 
 test('native object emit triggers a ZooKeeper emit', (t) => {
     const zk = new ZooKeeper({});
 
     zk.on('helloworld', (a, b, c) => {
-        t.equal(a, 1);
-        t.equal(b, 2);
-        t.equal(c, 3);
-        t.end();
+        t.is(a, 1);
+        t.is(b, 2);
+        t.is(c, 3);
     });
 
     zk.native.emit('helloworld', 1, 2, 3);
@@ -37,9 +36,8 @@ test('native object emits connect and pass an instance of the current ZooKeeper'
 
     zk.on('connect', (a, b, c) => {
         t.true(a instanceof ZooKeeper);
-        t.equal(b, 2);
-        t.equal(c, 3);
-        t.end();
+        t.is(b, 2);
+        t.is(c, 3);
     });
 
     zk.native.emit('connect', 1, 2, 3);
@@ -50,9 +48,8 @@ test('native object emits close and pass an instance of the current ZooKeeper', 
 
     zk.on('close', (a, b, c) => {
         t.true(a instanceof ZooKeeper);
-        t.equal(b, 2);
-        t.equal(c, 3);
-        t.end();
+        t.is(b, 2);
+        t.is(c, 3);
     });
 
     zk.native.emit('close', 1, 2, 3);
@@ -63,7 +60,7 @@ test('native zookeeper add_auth', (t) => {
 
     const zk = new ZooKeeper({});
 
-    t.throws(() => zk.native.add_auth('digest'), 'expected 3 arguments');
-    t.throws(() => zk.native.add_auth('digest', 'user:'), 'expected 3 arguments');
-    t.doesNotThrow(() => zk.native.add_auth('digest', 'user:', () => {}), 'expected 3 arguments');
+    t.throws(() => zk.native.add_auth('digest'), undefined, 'expected 3 arguments');
+    t.throws(() => zk.native.add_auth('digest', 'user:'), undefined, 'expected 3 arguments');
+    t.notThrows(() => zk.native.add_auth('digest', 'user:', () => {}), undefined, 'expected 3 arguments');
 });

--- a/tests/unit/zookeeper/proxypropertiestest.js
+++ b/tests/unit/zookeeper/proxypropertiestest.js
@@ -1,4 +1,4 @@
-const test = require('tape');
+const test = require('ava');
 
 const ZooKeeper = require('../../../lib/zookeeper');
 
@@ -7,9 +7,9 @@ test('native zookeeper proxy properties are added to the ZooKeeper instance', (t
 
     const zk = new ZooKeeper({});
 
-    t.equal(zk.state, 0);
-    t.equal(zk.timeout, -1);
-    t.equal(zk.client_id, '0');
-    t.equal(zk.client_password, '00000000000000000000000000000000');
-    t.equal(zk.is_unrecoverable, 0);
+    t.is(zk.state, 0);
+    t.is(zk.timeout, -1);
+    t.is(zk.client_id, '0');
+    t.is(zk.client_password, '00000000000000000000000000000000');
+    t.is(zk.is_unrecoverable, 0);
 });


### PR DESCRIPTION


## Description
Solves https://github.com/yfinkelstein/node-zookeeper/issues/276

## Motivation and Context
Both `tape` and `tap-spec` seems to be not longer maintained. `tap-spec` has raised npm audit warnings.

A simple solution is to use `Ava` instead, a tool that is actively maintained.

## How Has This Been Tested?
npm run test-unit
npm run test-components

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/yfinkelstein/node-zookeeper/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/yfinkelstein/node-zookeeper/blob/master/CONTRIBUTING.md).
- [ x] I have updated the documentation accordingly (if applicable).
