### PR TITLE
feat: add a Boolean "path exists" function

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ Have a look at the code in the [examples](./examples) folder: with __master__, _
     * `ttl` is optional. Must be positive if a TTL flag is used. See [Input parameters](#input-parameters)
 * `mkdirp(path, callback(Error))`
 * `stat = await exists(path, watch)`
-    * rejects if node does not exist
+    * rejects if node does not exist. There's also a `pathExists` as an alternative.
+* `trueOrFalseValue = await pathExists(path, watch)`
 * `data = await get(path, watch)`
 * `children = await get_children(path, watch)`
 * `[children, stat] = await get_children2( path, watch)`
@@ -123,7 +124,8 @@ Have a look at the code in the [examples](./examples) folder: with __master__, _
 *The watcher methods are forward-looking subscriptions that can recieve multiple callbacks whenever a matching event occurs.*
 
 * `stat = await w_exists(path, watch_cb)`
-    * rejects if node does not exist
+    * rejects if node does not exist. There's also a `w_pathExists` as an alternative.
+* `trueOrFalseValue = await w_pathExists(path, watch)`
 * `data = await w_get(path, watch_cb)`
 * `children = await w_get_children(path, watch_cb)`
 * `[children, stat] = await w_get_children2 (path, watch_cb)`

--- a/examples/exists.js
+++ b/examples/exists.js
@@ -1,0 +1,29 @@
+const { constants } = require('./wrapper');
+const { createNodes } = require('./setup');
+
+const logger = require('./logger');
+
+async function verifyNonExisting(client) {
+    const tempNode = '/my-temporary-node';
+
+    const doesExist = await client.w_pathExists(tempNode, (data) => logger.log(`Node created with data: ${data}`));
+    logger.log(`Does ${tempNode} exist? ${doesExist}`);
+
+    setTimeout(async () => {
+        createNodes(client, [tempNode], constants.ZOO_EPHEMERAL);
+
+        const exists = await client.pathExists(tempNode, false);
+        logger.log(`Does ${tempNode} exist now? ${exists}`);
+    }, 3000);
+}
+
+async function verifyTheNodeExistsFeature(client) {
+    const doesStatusExist = await client.pathExists('/status', false);
+    logger.log(`Does the /status node exist? ${doesStatusExist}`);
+
+    await verifyNonExisting(client);
+}
+
+module.exports = {
+    verifyTheNodeExistsFeature,
+};

--- a/examples/index.js
+++ b/examples/index.js
@@ -4,6 +4,7 @@ const { electLeader } = require('./electleader');
 const { createWorker } = require('./createworker');
 const { listen } = require('./addlistener');
 const { addTask } = require('./addtask');
+const { verifyTheNodeExistsFeature } = require('./exists');
 
 const logger = require('./logger');
 const notifier = require('./notifier');
@@ -38,6 +39,8 @@ async function init() {
         });
 
         await electLeader(client, '/master');
+
+        await verifyTheNodeExistsFeature(client);
     });
 }
 

--- a/lib/typedeclarations.d.ts
+++ b/lib/typedeclarations.d.ts
@@ -497,11 +497,25 @@ declare module "zookeeper" {
         exists(path: string, watch: boolean): Promise<stat>;
         /**
          * @param {string} path
+         * @param {boolean} watch
+         * @fulfill {boolean}
+         * @returns {Promise.<boolean>}
+         */
+        pathExists(path: string, watch: boolean): Promise<boolean>;
+        /**
+         * @param {string} path
          * @param {function} watchCb
          * @fulfill {stat}
          * @returns {Promise.<stat>}
          */
         w_exists(path: string, watchCb: Function): Promise<stat>;
+        /**
+         * @param {string} path
+         * @param {function} watchCb
+         * @fulfill {boolean}
+         * @returns {Promise.<boolean>}
+         */
+        w_pathExists(path: string, watchCb: Function): Promise<boolean>;
         /**
          * @param {string} path
          * @param {boolean} watch

--- a/lib/zk_promise.js
+++ b/lib/zk_promise.js
@@ -57,7 +57,7 @@ class ZooKeeperPromise extends ZooKeeper {
     /**
      * @param {string} path
      * @param {boolean} watch
-     * @fulfill {stat}
+     * @fulfill {boolean}
      * @returns {Promise.<boolean>}
      */
     async pathExists(path, watch) {
@@ -83,7 +83,7 @@ class ZooKeeperPromise extends ZooKeeper {
     /**
      * @param {string} path
      * @param {function} watchCb
-     * @fulfill {stat}
+     * @fulfill {boolean}
      * @returns {Promise.<boolean>}
      */
     async w_pathExists(path, watchCb) {

--- a/lib/zk_promise.js
+++ b/lib/zk_promise.js
@@ -4,6 +4,14 @@ const ZkPromise = require('./promise');
 const ZooKeeper = require('./zookeeper');
 const zkConstants = require('./constants');
 
+function isTruthy(data) {
+    if (data) {
+        return true;
+    }
+
+    return false;
+}
+
 /**
  * A promisified version of the ZooKeeper class
  * @class
@@ -48,12 +56,44 @@ class ZooKeeperPromise extends ZooKeeper {
 
     /**
      * @param {string} path
+     * @param {boolean} watch
+     * @fulfill {stat}
+     * @returns {Promise.<boolean>}
+     */
+    async pathExists(path, watch) {
+        try {
+            const stat = await this.exists(path, watch);
+
+            return isTruthy(stat);
+        } catch (e) {
+            return false;
+        }
+    }
+
+    /**
+     * @param {string} path
      * @param {function} watchCb
      * @fulfill {stat}
      * @returns {Promise.<stat>}
      */
     w_exists(path, watchCb) {
         return this.promisify(super.aw_exists, [path, watchCb]);
+    }
+
+    /**
+     * @param {string} path
+     * @param {function} watchCb
+     * @fulfill {stat}
+     * @returns {Promise.<boolean>}
+     */
+    async w_pathExists(path, watchCb) {
+        try {
+            const stat = await this.w_exists(path, watchCb);
+
+            return isTruthy(stat);
+        } catch (e) {
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes issue #254 

## Motivation and Context
Avoiding a breaking change in the existing `exists` function, by adding a `pathExists` that will return a boolean value.

`true` if the path exists, `false` if not.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
`npm test` ok.
Added code to the `examples`, that runs the new functions.
CircleCI builds passed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/yfinkelstein/node-zookeeper/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/yfinkelstein/node-zookeeper/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly (if applicable).
