### PR TITLE
fix: explicitly handle async JavaScript failures.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ Have a look at the code in the [examples](./examples) folder: with __master__, _
 
 ### Methods: async/await enabled client methods
 
+:green_circle: New since 5.2.1 :red_circle:
+
+The async functions will reject, when the underlying client returns an error code. This is a bug fix. Before this, errors were failing silently.
+
 * `init(options)`
 * `connect(options, connect_cb)`
 * `close()`

--- a/README.md
+++ b/README.md
@@ -96,9 +96,7 @@ Have a look at the code in the [examples](./examples) folder: with __master__, _
 
 ### Methods: async/await enabled client methods
 
-:green_circle: New since 5.2.1 :red_circle:
-
-The async functions will reject, when the underlying client returns an error code. This is a bug fix. Before this, errors were failing silently.
+:green_circle: New since 5.2.1: :red_circle: the async functions will reject, when the underlying client returns an error code. This is a bug fix. Before this, errors were failing silently.
 
 * `init(options)`
 * `connect(options, connect_cb)`

--- a/examples/addtask.js
+++ b/examples/addtask.js
@@ -4,7 +4,7 @@ const { createNode } = require('./createnode');
 
 async function createTask(client, data) {
     // eslint-disable-next-line no-bitwise
-    const message = await createNode(client, '/tasks/task-', constants.ZOO_PERSISTENT | constants.ZOO_PERSISTENT_SEQUENTIAL, data);
+    const message = await createNode(client, '/tasks/task-', constants.ZOO_PERSISTENT | constants.ZOO_PERSISTENT_SEQUENTIAL, undefined, data);
     notifier.emit('addTask', message);
 }
 

--- a/examples/exists.js
+++ b/examples/exists.js
@@ -3,6 +3,21 @@ const { createNodes } = require('./setup');
 
 const logger = require('./logger');
 
+async function verifyResultCodeCheckInAsyncCall(client) {
+    const tempNode = '/my-temporary-node-to-verify-async-call';
+    const data = 'HELLOWORLD';
+    const version = 0;
+
+    createNodes(client, [tempNode], constants.ZOO_EPHEMERAL);
+    const res = await client.set(tempNode, data, version);
+
+    logger.log(`The client.set result: ${JSON.stringify(res)}`);
+
+    client.set('this-node-does-not-exist', data, version)
+        .then(() => logger.error('THIS WILL NOT HAPPEN.'))
+        .catch((error) => logger.log(`The error is: ${error}`));
+}
+
 async function verifyNonExisting(client) {
     const tempNode = '/my-temporary-node';
 
@@ -22,6 +37,7 @@ async function verifyTheNodeExistsFeature(client) {
     logger.log(`Does the /status node exist? ${doesStatusExist}`);
 
     await verifyNonExisting(client);
+    await verifyResultCodeCheckInAsyncCall(client);
 }
 
 module.exports = {

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -2,6 +2,19 @@ const deprecationLog = (className, methodName) => {
     console.warn(`ZOOKEEPER LOG: ${className}::${methodName} is being deprecated!`);
 };
 
+function findZkConstantByCode(code, constants) {
+    const fallback = ['unknown', code];
+
+    try {
+        const res = Object.entries(constants).find(([, v]) => v === code);
+
+        return res || fallback;
+    } catch (e) {
+        return fallback;
+    }
+}
+
 exports = module.exports = {
     deprecationLog,
+    findZkConstantByCode,
 };

--- a/lib/zk_promise.js
+++ b/lib/zk_promise.js
@@ -12,6 +12,16 @@ function isTruthy(data) {
     return false;
 }
 
+function findZkConstantByCode(code) {
+    try {
+        const res = Object.entries(zkConstants).find(([, v]) => v === code);
+
+        return res;
+    } catch (e) {
+        return ['unknown', code];
+    }
+}
+
 /**
  * A promisified version of the ZooKeeper class
  * @class
@@ -250,7 +260,14 @@ class ZooKeeperPromise extends ZooKeeper {
                     resolve(toReturn);
                 }
             };
-            fn.bind(this)(...args, callback);
+
+            const res = fn.bind(this)(...args, callback);
+
+            if (res < 0) {
+                const [key, value] = findZkConstantByCode(res);
+
+                reject(new Error(`fn: "${fn.name}" args: "${args}" result: "${key} ${value}"`));
+            }
         });
     }
 

--- a/lib/zk_promise.js
+++ b/lib/zk_promise.js
@@ -3,6 +3,7 @@
 const ZkPromise = require('./promise');
 const ZooKeeper = require('./zookeeper');
 const zkConstants = require('./constants');
+const { findZkConstantByCode } = require('./helper');
 
 function isTruthy(data) {
     if (data) {
@@ -10,16 +11,6 @@ function isTruthy(data) {
     }
 
     return false;
-}
-
-function findZkConstantByCode(code) {
-    try {
-        const res = Object.entries(zkConstants).find(([, v]) => v === code);
-
-        return res;
-    } catch (e) {
-        return ['unknown', code];
-    }
 }
 
 /**
@@ -264,7 +255,7 @@ class ZooKeeperPromise extends ZooKeeper {
             const res = fn.bind(this)(...args, callback);
 
             if (res < 0) {
-                const [key, value] = findZkConstantByCode(res);
+                const [key, value] = findZkConstantByCode(res, zkConstants);
 
                 reject(new Error(`fn: "${fn.name}" args: "${args}" result: "${key} ${value}"`));
             }

--- a/tests/unit/util/helpertest.js
+++ b/tests/unit/util/helpertest.js
@@ -1,6 +1,7 @@
 const sinon = require('sinon');
 const test = require('ava');
-const { deprecationLog } = require('../../../lib/helper');
+const zkConstants = require('../../../lib/constants');
+const { deprecationLog, findZkConstantByCode } = require('../../../lib/helper');
 
 class Test {
     static method() {
@@ -29,4 +30,24 @@ test('deprecation log gives proper message', (t) => {
     t.is(consoleStub.getCall(0).args[0], 'ZOOKEEPER LOG: Test::method is being deprecated!');
 
     consoleStub.restore();
+});
+
+test('finds the BAD ARGUMENTS constant', (t) => {
+    t.plan(2);
+    const expected = -8;
+
+    const res = findZkConstantByCode(expected, zkConstants);
+
+    t.is(res[0], 'ZBADARGUMENTS');
+    t.is(res[1], expected);
+});
+
+test('finds constants with fallback', (t) => {
+    t.plan(2);
+    const expected = 4711;
+
+    const res = findZkConstantByCode(expected, zkConstants);
+
+    t.is(res[0], 'unknown');
+    t.is(res[1], expected);
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Explicit checks for errors by validating the result code coming from the C Client.

## Description
<!--- Describe your changes in detail -->
All calls to methods in the promisified version of the JavaScript client has now an explicit result code check. A result code that has a negative value is a failure, and the method will from now on perform a `reject`.

Before this, errors failed silently, as described in issue #237 - the issue is about the `set` method, but the error exists in all promisified method calls.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #237 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
npm tests passed
CircleCI passed
added example code that verifies the behaviour.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/yfinkelstein/node-zookeeper/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/yfinkelstein/node-zookeeper/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly (if applicable).
