### PR TITLE
Replace lodash with vanilla js and remove unused dependencies

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -14,7 +14,17 @@ function findZkConstantByCode(code, constants) {
     }
 }
 
+function isString(data) {
+    return typeof data === 'string' || data instanceof String;
+}
+
+function isFunction(data) {
+    return typeof data === 'function';
+}
+
 module.exports = {
     deprecationLog,
     findZkConstantByCode,
+    isString,
+    isFunction,
 };

--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -2,10 +2,10 @@
 /* eslint-disable camelcase */
 const { apply, waterfall } = require('async');
 const { EventEmitter } = require('events');
-const _ = require('lodash');
 const { join, normalize } = require('path');
 const util = require('util');
 const NativeZk = require('node-gyp-build')(join(__dirname, '..')).ZooKeeper;
+const { isString, isFunction } = require('./helper');
 
 const Async = {
     apply,
@@ -69,7 +69,7 @@ class ZooKeeper extends EventEmitter {
     constructor(config) {
         super();
 
-        if (_.isString(config)) {
+        if (isString(config)) {
             this.config = { connect: config };
         } else {
             this.config = config;
@@ -96,7 +96,7 @@ class ZooKeeper extends EventEmitter {
             };
         } else if (logger === false) {
             this.logger = undefined;
-        } else if (_.isFunction(logger)) {
+        } else if (isFunction(logger)) {
             this.logger = logger;
         } else {
             throw new Error('InvalidArgument: logger must be a function or true/false to utilize default logger');
@@ -113,16 +113,16 @@ class ZooKeeper extends EventEmitter {
      * @returns {ZooKeeper}
      */
     init(config) {
-        if (_.isString(config)) {
+        if (isString(config)) {
             // eslint-disable-next-line no-param-reassign
             config = { connect: config };
         }
         if (this.config) {
             // eslint-disable-next-line no-param-reassign
-            config = config ? _.defaults(config, this.config) : this.config;
+            config = config ? Object.assign(config, this.config) : this.config;
         }
         this.log(`Calling init with ${util.inspect(config)}`);
-        if (!_.isUndefined(config.data_as_buffer)) {
+        if (config.data_as_buffer !== undefined) {
             this.data_as_buffer = config.data_as_buffer;
             this.log('Encoding for data output: %s', this.encoding);
         }
@@ -137,7 +137,7 @@ class ZooKeeper extends EventEmitter {
      */
     connect(options, cb) {
         let callback;
-        if (_.isFunction(options)) {
+        if (isFunction(options)) {
             callback = options;
             this.init({});
         } else {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     },
     "devDependencies": {
         "@types/node": "17.x",
-        "ava": "4.0.0",
+        "ava": "4.0.1",
         "eslint": "8.x",
         "eslint-config-airbnb-base": "15.x",
         "eslint-plugin-import": "2.x",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
         "eslint-plugin-import": "2.x",
         "node-gyp": "8.4.1",
         "prebuildify": "5.0.0",
-        "proxyquire": "2.x",
         "sinon": "12.x",
         "typescript": "^4.0.5"
     },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
         "async": "3.2.x",
         "decompress": "4.2.x",
         "decompress-targz": "4.1.x",
-        "lodash": "4.x",
         "nan": "2.x",
         "node-gyp-build": "^4.2.3",
         "shelljs": "0.8.x"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
         "ava": "4.0.0",
         "eslint": "8.x",
         "eslint-config-airbnb-base": "15.x",
-        "eslint-plugin-ava": "13.x",
         "eslint-plugin-import": "2.x",
         "node-gyp": "8.4.1",
         "prebuildify": "5.0.0",

--- a/tests/components/converterstest.js
+++ b/tests/components/converterstest.js
@@ -2,7 +2,6 @@ const test = require('ava');
 const converters = require('./build/Release/converters.node');
 
 test('Integer is converted to string', (t) => {
-    t.plan(2);
     const expected = 4711;
     const res = converters.toStrTest(expected);
 
@@ -11,7 +10,6 @@ test('Integer is converted to string', (t) => {
 });
 
 test('Unix time is converted to date', (t) => {
-    t.plan(1);
     const now = Date.now();
 
     const d = new Date(now);
@@ -27,7 +25,6 @@ test('Unix time is converted to date', (t) => {
 });
 
 test('Object value is converted to bool', (t) => {
-    t.plan(2);
     const expected = true;
     const res = converters.toBoolTest({ val: 'true' });
 
@@ -36,7 +33,6 @@ test('Object value is converted to bool', (t) => {
 });
 
 test('Object value is converted to integer', (t) => {
-    t.plan(2);
     const expected = 4711;
     const expectedNeg = -1;
     const res = converters.toIntTest({ val: '4711' });
@@ -47,7 +43,6 @@ test('Object value is converted to integer', (t) => {
 });
 
 test('Object value is converted to unsigned integer', (t) => {
-    t.plan(1);
     const expected = 4711;
     const res = converters.toUintTest('4711');
 

--- a/tests/integration/getAndSettest.js
+++ b/tests/integration/getAndSettest.js
@@ -2,8 +2,6 @@ const test = require('ava');
 const { constants, createClient } = require('./helpers/createClient');
 
 test('can create an node with data and get data from the node', async (t) => {
-    t.plan(1);
-
     const nodeName = '/my-get-and-set-node';
     const data = 'data as a string';
 
@@ -26,8 +24,6 @@ test('can create an node with data and get data from the node', async (t) => {
 });
 
 test('can create an node, set and get data from the node', async (t) => {
-    t.plan(1);
-
     const nodeName = '/my-node-to-be-set';
     const data = 'data as a string';
 
@@ -52,8 +48,6 @@ test('can create an node, set and get data from the node', async (t) => {
 });
 
 test('can create a node with data as buffer and get data as a buffer from the node', async (t) => {
-    t.plan(1);
-
     const nodeName = '/my-node-to-create-with-buffer-data';
     const data = Buffer.from('data as a string');
 
@@ -75,8 +69,6 @@ test('can create a node with data as buffer and get data as a buffer from the no
 });
 
 test('can set data as buffer and get data as a buffer from the node', async (t) => {
-    t.plan(1);
-
     const nodeName = '/my-node-to-be-set-with-buffer-data';
     const data = Buffer.from('data as a string');
 

--- a/tests/integration/getChildrentest.js
+++ b/tests/integration/getChildrentest.js
@@ -2,8 +2,6 @@ const test = require('ava');
 const { constants, createClient } = require('./helpers/createClient');
 
 test('can create and get children', async (t) => {
-    t.plan(1);
-
     const expected = 'child';
     const parentNode = '/parent';
     const childNode = `${parentNode}/${expected}`;
@@ -31,8 +29,6 @@ test('can create and get children', async (t) => {
 });
 
 test('can create and get children (the get_children2 function) with stat', async (t) => {
-    t.plan(2);
-
     const expected = 'child';
     const parentNode = '/parent-with-stat';
     const childNode = `${parentNode}/${expected}`;
@@ -61,8 +57,6 @@ test('can create and get children (the get_children2 function) with stat', async
 });
 
 test('returns empty when no children', async (t) => {
-    t.plan(1);
-
     const parentNode = '/the-parent-node-without-children';
 
     const client = createClient();
@@ -86,8 +80,6 @@ test('returns empty when no children', async (t) => {
 });
 
 test('returns empty when no node', async (t) => {
-    t.plan(1);
-
     const parentNode = '/this-is-a-non-existing-node';
 
     const client = createClient();

--- a/tests/integration/makeAndDeleteDirtest.js
+++ b/tests/integration/makeAndDeleteDirtest.js
@@ -2,8 +2,6 @@ const test = require('ava');
 const { createClient } = require('./helpers/createClient');
 
 test('can create and delete a node containing sub nodes', async (t) => {
-    t.plan(8);
-
     const path = ['/one', '/two', '/three'];
     const fullPath = path.join('');
     const twoStepPath = path.slice(0, 2).join('');

--- a/tests/integration/sessiontest.js
+++ b/tests/integration/sessiontest.js
@@ -2,8 +2,6 @@ const test = require('ava');
 const { constants, createClient } = require('./helpers/createClient');
 
 test('can init and close more than one client', async (t) => {
-    t.plan(3);
-
     const client = createClient();
     const secondClient = createClient();
 
@@ -28,8 +26,6 @@ test('can init and close more than one client', async (t) => {
 });
 
 test('two connected clients can create and fetch nodes', async (t) => {
-    t.plan(6);
-
     const pathOne = '/first';
     const pathTwo = '/second';
 
@@ -65,8 +61,6 @@ test('two connected clients can create and fetch nodes', async (t) => {
 });
 
 test('closed client cannot create node', async (t) => {
-    t.plan(1);
-
     const pathOne = '/first';
     const firstClient = createClient();
     const secondClient = createClient(firstClient.client_id, firstClient.client_password);

--- a/tests/unit/index/apitest.js
+++ b/tests/unit/index/apitest.js
@@ -3,8 +3,6 @@ const test = require('ava');
 const ZooKeeper = require('../../../lib/index');
 
 function assertPublicApi(zk, t) {
-    t.plan(26);
-
     t.is(typeof zk.a_create, 'function');
     t.is(typeof zk.a_createTtl, 'function');
     t.is(typeof zk.a_exists, 'function');

--- a/tests/unit/index/configtest.js
+++ b/tests/unit/index/configtest.js
@@ -21,3 +21,22 @@ test('inject connection config as a string', (t) => {
     t.is(zk.config.connect, expected);
     t.is(Object.keys(zk.config).length, 1);
 });
+
+test('does combine config from constructor and the init fn similar to the lodash "defaults" fn', (t) => {
+    const expectedConnect = '127.0.0.1:2181';
+    const expectedTimeout = 1;
+    const expectedDebugLevel = 42;
+
+    const conf = {
+        connect: expectedConnect,
+        timeout: expectedTimeout,
+        debug_level: expectedDebugLevel,
+    };
+
+    const zk = new ZooKeeper(conf);
+    zk.init({ connect: 'should-not-override', timeout: 4711 });
+
+    t.is(zk.config.connect, expectedConnect);
+    t.is(zk.config.timeout, expectedTimeout);
+    t.is(zk.config.debug_level, expectedDebugLevel);
+});

--- a/tests/unit/index/configtest.js
+++ b/tests/unit/index/configtest.js
@@ -2,8 +2,6 @@ const test = require('ava');
 const ZooKeeper = require('../../../lib/index');
 
 test('inject config', (t) => {
-    t.plan(1);
-
     const expected = '127.0.0.1:2181';
 
     const zk = new ZooKeeper({ connect: expected });
@@ -12,8 +10,6 @@ test('inject config', (t) => {
 });
 
 test('inject connection config as a string', (t) => {
-    t.plan(2);
-
     const expected = '127.0.0.1:2181';
 
     const zk = new ZooKeeper(expected);

--- a/tests/unit/index/encodingtest.js
+++ b/tests/unit/index/encodingtest.js
@@ -2,8 +2,6 @@ const test = require('ava');
 const ZooKeeper = require('../../../lib/index');
 
 test('inject encoding will set data as buffer to false', (t) => {
-    t.plan(2);
-
     const expected = 'utf-8';
 
     const zk = new ZooKeeper();

--- a/tests/unit/index/loggertest.js
+++ b/tests/unit/index/loggertest.js
@@ -3,8 +3,6 @@ const test = require('ava');
 const ZooKeeper = require('../../../lib/index');
 
 test('Inject custom logger', (t) => {
-    t.plan(1);
-
     const zk = new ZooKeeper();
     zk.setLogger(console.log);
 
@@ -12,8 +10,6 @@ test('Inject custom logger', (t) => {
 });
 
 test('Use default logger', (t) => {
-    t.plan(1);
-
     const zk = new ZooKeeper();
     zk.setLogger(true);
 
@@ -21,8 +17,6 @@ test('Use default logger', (t) => {
 });
 
 test('Explicit set use no logger', (t) => {
-    t.plan(1);
-
     const zk = new ZooKeeper();
     zk.setLogger(false);
 

--- a/tests/unit/util/helpertest.js
+++ b/tests/unit/util/helpertest.js
@@ -1,7 +1,12 @@
 const sinon = require('sinon');
 const test = require('ava');
 const zkConstants = require('../../../lib/constants');
-const { deprecationLog, findZkConstantByCode } = require('../../../lib/helper');
+const {
+    deprecationLog,
+    findZkConstantByCode,
+    isString,
+    isFunction,
+} = require('../../../lib/helper');
 
 class Test {
     static method() {
@@ -50,4 +55,22 @@ test('finds constants with fallback', (t) => {
 
     t.is(res[0], 'unknown');
     t.is(res[1], expected);
+});
+
+test('identifies data as strings', (t) => {
+    t.true(isString('data'));
+    t.true(isString(''));
+
+    t.true(isString(new String('data'))); // eslint-disable-line no-new-wrappers
+
+    t.false(isString(1));
+    t.false(isString({ key: 'value' }));
+});
+
+test('identifies data as functions', (t) => {
+    t.true(isFunction(() => {}));
+    t.true(isFunction(Test.method));
+
+    t.false(isFunction('data'));
+    t.false(isFunction(null));
 });

--- a/tests/unit/util/helpertest.js
+++ b/tests/unit/util/helpertest.js
@@ -16,8 +16,6 @@ class Test {
 
 test('deprecation log is called with proper arguments', (t) => {
     const deprecationLogStub = sinon.stub();
-    t.plan(3);
-
     deprecationLogStub(Test.name, 'method');
 
     t.is(deprecationLogStub.callCount, 1);
@@ -27,8 +25,6 @@ test('deprecation log is called with proper arguments', (t) => {
 
 test('deprecation log gives proper message', (t) => {
     const consoleStub = sinon.stub(console, 'warn');
-    t.plan(2);
-
     Test.method();
 
     t.is(consoleStub.callCount, 1);
@@ -38,7 +34,6 @@ test('deprecation log gives proper message', (t) => {
 });
 
 test('finds the BAD ARGUMENTS constant', (t) => {
-    t.plan(2);
     const expected = -8;
 
     const res = findZkConstantByCode(expected, zkConstants);
@@ -48,7 +43,6 @@ test('finds the BAD ARGUMENTS constant', (t) => {
 });
 
 test('finds constants with fallback', (t) => {
-    t.plan(2);
     const expected = 4711;
 
     const res = findZkConstantByCode(expected, zkConstants);

--- a/tests/unit/util/promisetest.js
+++ b/tests/unit/util/promisetest.js
@@ -4,8 +4,6 @@ const test = require('ava');
 const ZkPromise = require('../../../lib/promise');
 
 test('ZkPromise get', (t) => {
-    t.plan(1);
-
     const expected = 'value';
     const promise = ZkPromise.resolve({
         property: expected,
@@ -17,8 +15,6 @@ test('ZkPromise get', (t) => {
 });
 
 test('ZkPromise put', (t) => {
-    t.plan(1);
-
     const expected = 'value';
     const promise = ZkPromise.resolve({});
 
@@ -28,8 +24,6 @@ test('ZkPromise put', (t) => {
 });
 
 test('ZkPromise call', (t) => {
-    t.plan(1);
-
     const promise = ZkPromise.resolve({
         multiply: (a, b) => a * b,
     });
@@ -40,8 +34,6 @@ test('ZkPromise call', (t) => {
 });
 
 test('ZkPromise addCallback', (t) => {
-    t.plan(3);
-
     const callback = sinon.stub().callsFake((value) => value * 2);
     const promise = ZkPromise.resolve(10);
 
@@ -53,8 +45,6 @@ test('ZkPromise addCallback', (t) => {
 });
 
 test('ZkPromise addErrback', (t) => {
-    t.plan(3);
-
     const callback = sinon.stub().callsFake((value) => value * 2);
     const promise = ZkPromise.reject(10);
 
@@ -66,8 +56,6 @@ test('ZkPromise addErrback', (t) => {
 });
 
 test('ZkPromise addBoth', (t) => {
-    t.plan(7);
-
     const callback = sinon.stub().callsFake((value) => value * 2);
     const errback = sinon.stub().callsFake(() => {
         throw new Error('errback!');
@@ -91,8 +79,6 @@ test('ZkPromise addBoth', (t) => {
 });
 
 test('ZkPromise addCallbacks', (t) => {
-    t.plan(9);
-
     const callback = sinon.stub().callsFake((value) => value * 2);
     const errback = sinon.stub().callsFake(() => {
         throw new Error('errback!');

--- a/tests/unit/zookeeper/exportedconstantstest.js
+++ b/tests/unit/zookeeper/exportedconstantstest.js
@@ -7,16 +7,12 @@ const ZooKeeper = require('../../../lib/zookeeper');
 const keys = Object.keys(NativeZk);
 
 test('native static constants are exported', (t) => {
-    t.plan(keys.length);
-
     keys.forEach((key) => {
         t.is(constants[key], NativeZk[key]);
     });
 });
 
 test('deprecated legacy event constants are exported', (t) => {
-    t.plan(8);
-
     t.is(ZooKeeper.on_closed, 'close');
     t.is(ZooKeeper.on_connected, 'connect');
     t.is(ZooKeeper.on_connecting, 'connecting');
@@ -29,8 +25,6 @@ test('deprecated legacy event constants are exported', (t) => {
 });
 
 test('legacy event constants are exported', (t) => {
-    t.plan(8);
-
     t.is(constants.on_closed, 'close');
     t.is(constants.on_connected, 'connect');
     t.is(constants.on_connecting, 'connecting');

--- a/tests/unit/zookeeper/nativeobjecttest.js
+++ b/tests/unit/zookeeper/nativeobjecttest.js
@@ -4,16 +4,12 @@ const NativeZk = require('node-gyp-build')(join(__dirname, '../../../')).ZooKeep
 const ZooKeeper = require('../../../lib/zookeeper');
 
 test('ZooKeeper instance creates an instance of the native object', (t) => {
-    t.plan(1);
-
     const zk = new ZooKeeper({});
 
     t.true(zk.native instanceof NativeZk);
 });
 
 test('native object is extended with an emit function', (t) => {
-    t.plan(1);
-
     const zk = new ZooKeeper({});
 
     t.is(typeof zk.native.emit, 'function');
@@ -56,8 +52,6 @@ test('native object emits close and pass an instance of the current ZooKeeper', 
 });
 
 test('native zookeeper add_auth', (t) => {
-    t.plan(3);
-
     const zk = new ZooKeeper({});
 
     t.throws(() => zk.native.add_auth('digest'), undefined, 'expected 3 arguments');

--- a/tests/unit/zookeeper/proxypropertiestest.js
+++ b/tests/unit/zookeeper/proxypropertiestest.js
@@ -3,8 +3,6 @@ const test = require('ava');
 const ZooKeeper = require('../../../lib/zookeeper');
 
 test('native zookeeper proxy properties are added to the ZooKeeper instance', (t) => {
-    t.plan(5);
-
     const zk = new ZooKeeper({});
 
     t.is(zk.state, 0);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Less depencencies.

## Description
<!--- Describe your changes in detail -->
Replaced lodash with vanilla JavaScript. 

NOTE: the `_.defaults` lodash function is replaced with `Object.assign` (src and target flipped) to have a similar behaviour as the lodash function. But it isn't 100% the same. If the original object has a key with an `undefined` value, it will behave differently. 

Removed unused deps to `proxyquire` and `ava-eslint-plugin`.

Removed unnecessary usage of the `Ava` function `t.plan()`, according to the [Ava guidelines.](https://github.com/avajs/ava/blob/main/docs/recipes/when-to-use-plan.md)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Less dependencies is also less MB in the node_modules folder. This will make room for some more prebuilds (that are quite heavy).

Fixes #299 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
npm test ✅ 
npm run lint ✅ 
npm run test-integration ✅ 
npm run test-components ✅ 
CircleCI ✅ 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/yfinkelstein/node-zookeeper/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/yfinkelstein/node-zookeeper/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly (if applicable).
