### PR TITLE
fix: node-gyp is included in npm already

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
         "eslint": "8.x",
         "eslint-config-airbnb-base": "15.x",
         "eslint-plugin-import": "2.x",
-        "node-gyp": "8.4.1",
         "prebuildify": "5.0.0",
         "sinon": "12.x",
         "typescript": "^4.0.5"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Remove `node-gyp` from dependencies.

## Description
<!--- Describe your changes in detail -->
`node-gyp` is already included in Node/npm and `node-gyp-build` uses that one, so does `prebuildify` (if there isn't any other version specified locally). See [Q&A about it here](https://github.com/prebuild/node-gyp-build/issues/41).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Less dependencies, will produce less weight in the `node_modules` folder and will probably speed up the install process.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
npm test ✅ 
npm run test-components ✅ 
npm run test-integration ✅ 
CircleCI ✅ 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/yfinkelstein/node-zookeeper/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/yfinkelstein/node-zookeeper/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly (if applicable).
