### PR TITLE
fixed windows path normalize / => \\

### DIFF
--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -45,12 +45,12 @@ const create = (con, p, cb) => {
  * @param {mkdirCb} callback
  */
 const mkdirp = (con, p, callback) => {
-    const dirs = normalize(p).split('/').slice(1); // remove empty string at the start.
+    const dirs = normalize(p).replace(/\\/g, '/').split('/').slice(1); // remove empty string at the start.
 
     const tasks = [];
     dirs.forEach((dir, i) => {
         let subpath = `/${dirs.slice(0, i).join('/')}/${dir}`;
-        subpath = normalize(subpath); // remove extra `/` in first iteration
+        subpath = normalize(subpath).replace(/\\/g, '/'); // remove extra `/` in first iteration
         tasks.push(Async.apply(create, con, subpath));
     });
     Async.waterfall(tasks, (err) => {
@@ -407,7 +407,7 @@ class ZooKeeper extends EventEmitter {
      */
     a_reconfig(joining, leaving, members, config_version, dataCb) {
         this.log('Calling a_reconfig with '
-                                + `${util.inspect([joining, leaving, members, config_version, dataCb])}`);
+            + `${util.inspect([joining, leaving, members, config_version, dataCb])}`);
         return this.native.a_reconfig(
             joining,
             leaving,

--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -2,7 +2,7 @@
 /* eslint-disable camelcase */
 const { apply, waterfall } = require('async');
 const { EventEmitter } = require('events');
-const { join, normalize, sep } = require('path');
+const { join, posix, sep } = require('path');
 const util = require('util');
 const NativeZk = require('node-gyp-build')(join(__dirname, '..')).ZooKeeper;
 const { isString, isFunction } = require('./helper');
@@ -45,12 +45,12 @@ const create = (con, p, cb) => {
  * @param {mkdirCb} callback
  */
 const mkdirp = (con, p, callback) => {
-    const dirs = normalize(p).split(sep).slice(1); // remove empty string at the start.
+    const dirs = posix.normalize(p).split(sep).slice(1); // remove empty string at the start.
 
     const tasks = [];
     dirs.forEach((dir, i) => {
         let subpath = `/${dirs.slice(0, i).join('/')}/${dir}`;
-        subpath = normalize(subpath); // remove extra `/` in first iteration
+        subpath = posix.normalize(subpath); // remove extra `/` in first iteration
         tasks.push(Async.apply(create, con, subpath));
     });
     Async.waterfall(tasks, (err) => {

--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -2,7 +2,7 @@
 /* eslint-disable camelcase */
 const { apply, waterfall } = require('async');
 const { EventEmitter } = require('events');
-const { join, normalize } = require('path');
+const { join, normalize, sep } = require('path');
 const util = require('util');
 const NativeZk = require('node-gyp-build')(join(__dirname, '..')).ZooKeeper;
 const { isString, isFunction } = require('./helper');
@@ -45,12 +45,12 @@ const create = (con, p, cb) => {
  * @param {mkdirCb} callback
  */
 const mkdirp = (con, p, callback) => {
-    const dirs = normalize(p).replace(/\\/g, '/').split('/').slice(1); // remove empty string at the start.
+    const dirs = normalize(p).split(sep).slice(1); // remove empty string at the start.
 
     const tasks = [];
     dirs.forEach((dir, i) => {
         let subpath = `/${dirs.slice(0, i).join('/')}/${dir}`;
-        subpath = normalize(subpath).replace(/\\/g, '/'); // remove extra `/` in first iteration
+        subpath = normalize(subpath); // remove extra `/` in first iteration
         tasks.push(Async.apply(create, con, subpath));
     });
     Async.waterfall(tasks, (err) => {

--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -2,7 +2,7 @@
 /* eslint-disable camelcase */
 const { apply, waterfall } = require('async');
 const { EventEmitter } = require('events');
-const { join, posix, sep } = require('path');
+const { join, posix } = require('path');
 const util = require('util');
 const NativeZk = require('node-gyp-build')(join(__dirname, '..')).ZooKeeper;
 const { isString, isFunction } = require('./helper');
@@ -45,7 +45,7 @@ const create = (con, p, cb) => {
  * @param {mkdirCb} callback
  */
 const mkdirp = (con, p, callback) => {
-    const dirs = posix.normalize(p).split(sep).slice(1); // remove empty string at the start.
+    const dirs = posix.normalize(p).split(posix.sep).slice(1); // remove empty string at the start.
 
     const tasks = [];
     dirs.forEach((dir, i) => {


### PR DESCRIPTION
Fixed that the normalize method in the Windows environment changed the separator of the path

## Description

on windows platform

normalize("/service/helloservice/consumer") returns “\\\service\\\helloservice\\\consumer”

it will cause slice to return an empty array