### PR TITLE
fix: get functions returns an array of [stat, string|Buffer]

### DIFF
--- a/lib/typedeclarations.d.ts
+++ b/lib/typedeclarations.d.ts
@@ -519,17 +519,17 @@ declare module "zookeeper" {
         /**
          * @param {string} path
          * @param {boolean} watch
-         * @fulfill {string|Buffer}
-         * @returns {Promise.<string|Buffer>}
+         * @fulfill {Array} [stat, data] - stat: object, data: string|Buffer
+         * @returns {Promise.<Array>} [stat, data] - stat: object, data: string|Buffer
          */
-        get(path: string, watch: boolean): Promise<string | Buffer>;
+        get(path: string, watch: boolean): Promise<any[]>;
         /**
          * @param {string} path
          * @param {function} watchCb
-         * @fulfill {string|Buffer}
-         * @returns {Promise.<string|Buffer>}
+         * @fulfill {Array} [stat, data] - stat: object, data: string|Buffer
+         * @returns {Promise.<Array>} [stat, data] - stat: object, data: string|Buffer
          */
-        w_get(path: string, watchCb: Function): Promise<string | Buffer>;
+        w_get(path: string, watchCb: Function): Promise<any[]>;
         /**
          * @param {string} path
          * @param {boolean} watch

--- a/lib/zk_promise.js
+++ b/lib/zk_promise.js
@@ -100,8 +100,8 @@ class ZooKeeperPromise extends ZooKeeper {
     /**
      * @param {string} path
      * @param {boolean} watch
-     * @fulfill {string|Buffer}
-     * @returns {Promise.<string|Buffer>}
+     * @fulfill {Array} [stat, data] - stat: object, data: string|Buffer
+     * @returns {Promise.<Array>} [stat, data] - stat: object, data: string|Buffer
      */
     get(path, watch) {
         return this.promisify(super.a_get, [path, watch]);
@@ -110,8 +110,8 @@ class ZooKeeperPromise extends ZooKeeper {
     /**
      * @param {string} path
      * @param {function} watchCb
-     * @fulfill {string|Buffer}
-     * @returns {Promise.<string|Buffer>}
+     * @fulfill {Array} [stat, data] - stat: object, data: string|Buffer
+     * @returns {Promise.<Array>} [stat, data] - stat: object, data: string|Buffer
      */
     w_get(path, watchCb) {
         return this.promisify(super.aw_get, [path, watchCb]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed incorrect type definitions for the `get` and `w_get` functions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #304 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
CircleCI ✅ 
npm test ✅ 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/yfinkelstein/node-zookeeper/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/yfinkelstein/node-zookeeper/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly (if applicable).
