### PR TITLE
fix: Cannot start the zookeeper client in a Node.js Worker thread

### DIFF
--- a/src/node-zk.cpp
+++ b/src/node-zk.cpp
@@ -280,7 +280,7 @@ public:
             return;
         }
 
-        last_activity = uv_now(uv_default_loop());
+        last_activity = uv_now(Nan::GetCurrentEventLoop());
 
         #ifdef WIN32
             SOCKET oldFd = fd;
@@ -334,9 +334,9 @@ public:
 
              zk_io->data = this;
              #ifdef WIN32
-             	uv_poll_init_socket(uv_default_loop(), zk_io, fd);
+             	uv_poll_init_socket(Nan::GetCurrentEventLoop(), zk_io, fd);
              #else
-             	uv_poll_init(uv_default_loop(), zk_io, fd);
+             	uv_poll_init(Nan::GetCurrentEventLoop(), zk_io, fd);
              #endif
         }
 
@@ -387,7 +387,7 @@ public:
         LOG_DEBUG("zk_timer_cb fired");
 
         ZooKeeper *zk = static_cast<ZooKeeper*>(w->data);
-        int64_t now = uv_now(uv_default_loop());
+        int64_t now = uv_now(Nan::GetCurrentEventLoop());
         int64_t timeout = zk->last_activity + zk->tv.tv_sec * 1000 + zk->tv.tv_usec / 1000.;
 
         // if last_activity + tv.tv_sec is older than now, we did time out
@@ -421,7 +421,7 @@ public:
         }
         Ref();
 
-        uv_timer_init(uv_default_loop(), &zk_timer);
+        uv_timer_init(Nan::GetCurrentEventLoop(), &zk_timer);
         zk_timer.data = this;
 
         noResponseCounter = 0;


### PR DESCRIPTION
## Description
replace all `uv_default_loop()` by `Nan::GetCurrentEventLoop()`
here's [GetCurrentEventLoop](https://github.com/nodejs/nan/blob/8db8c8f544f2b6ce1b0859ef6ecdd0a3873a9e62/nan.h#L653) source code

## Motivation and Context
Related to #281 
The problem is uv_default_loop() return the main Node thread when program started, not the Worker's Event Loop in its isolated environment

## How Has This Been Tested?
same as #281 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have read the [code of conduct](https://github.com/yfinkelstein/node-zookeeper/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/yfinkelstein/node-zookeeper/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
