### PR TITLE
fix: remove code using FIPS_mode which is not available on all distros

### DIFF
--- a/deps/no-fipsmode.patch
+++ b/deps/no-fipsmode.patch
@@ -1,0 +1,9 @@
+diff -ur -p0 deps/zookeeper-client-c/src/zookeeper.c deps-patched/zookeeper-client-c/src/zookeeper.c
+--- deps/zookeeper-client-c/src/zookeeper.c	2022-09-10 16:36:21.122958700 +0200
++++ deps-patched/zookeeper-client-c/src/zookeeper.c	2022-09-10 16:32:05.092796200 +0200
+@@ -2595,5 +2594,0 @@ static int init_ssl_for_socket(zsock_t *
+-        if (FIPS_mode() == 0) {
+-            LOG_INFO(LOGCALLBACK(zh), "FIPS mode is OFF ");
+-        } else {
+-            LOG_INFO(LOGCALLBACK(zh), "FIPS mode is ON ");
+-        }

--- a/scripts/env.js
+++ b/scripts/env.js
@@ -34,6 +34,7 @@ const variables = {
     sourceFolder: `${rootFolder}/deps/zookeeper-client-c`,
     downloadedFileName,
     isWindows,
+    isLinux: process.platform === 'linux',
     isVerbose: !!process.env.ZK_INSTALL_VERBOSE,
 };
 

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -18,6 +18,8 @@ function applyPatches() {
         shell.sed('-i', '#include "zookeeper_log.h"', '#include "zookeeper_log.h"\n#include "winport.h"\n', `${destination}/zk_log.c`);
         shell.sed('-i', '#include "zookeeper.h"', '#include "winport.h"\n#include "zookeeper.h"\n', `${destination}/zk_adaptor.h`);
         shell.sed('-i', '#include "zk_adaptor.h"', '#include "zk_adaptor.h"\n#include "winport.h"\n', `${destination}/zookeeper.c`);
+    } else if (env.isLinux) {
+        shell.exec(`patch -d ${env.rootFolder} -p0 --forward < ${env.workFolder}/no-fipsmode.patch`);
     }
 }
 


### PR DESCRIPTION
As FIPS_mode is only used to conditionally print an info message this may be a reasonable fix for #318 

## Description
A mechanism to apply patches, in this case used to remove a problematic line of code from the source C files.

## Motivation and Context
See #318

## How Has This Been Tested?
It builds, installs and runs now

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/yfinkelstein/node-zookeeper/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/yfinkelstein/node-zookeeper/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly (if applicable).
