### PR TITLE
set the correct supported version of zookeeper server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### v 5.5.1 (2022-09-17)
+* fix: set the correct supported version of Apache ZooKeeper server (docs and package description). Pull request [322](https://github.com/yfinkelstein/node-zookeeper/pull/322) by @davidvujic
+
 #### v 5.5.0 (2022-09-17)
 * fix: Remove the OpenSSSL FIPS_mode check for Linux, Mac OS X and Windows.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 _node-zookeeper - A Node.js client for Apache Zookeeper._
 
-This node module is implemented on top of the __official ZooKeeper C Client API__, supporting ZooKeeper server v3.4.x - v3.8.x. Have a look at the [official docs](https://zookeeper.apache.org/doc/current/index.html) for further details on behavior.
+This node module is implemented on top of the __official ZooKeeper C Client API__, supporting ZooKeeper server v3.5.x - v3.8.x.
+Have a look at the [official docs](https://zookeeper.apache.org/doc/current/index.html) for further details on behavior.
 
 __Latest changes__ are described in the [changelog](./CHANGELOG.md)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "zookeeper",
     "description": "apache zookeeper client (zookeeper async API v3.5.x - v3.8.x)",
-    "version": "5.5.0",
+    "version": "5.5.1",
     "author": "Yuri Finkelstein <yurif2003@yahoo.com>",
     "license": "MIT",
     "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "zookeeper",
-    "description": "apache zookeeper client (zookeeper async API v3.4.x - v3.7.x)",
+    "description": "apache zookeeper client (zookeeper async API v3.5.x - v3.8.x)",
     "version": "5.5.0",
     "author": "Yuri Finkelstein <yurif2003@yahoo.com>",
     "license": "MIT",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The docs and the npm package description was not correct when stating the supported version of Apache ZooKeeper server.

## Description
<!--- Describe your changes in detail -->
Fixed in this PR.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
CircleCI tests passed. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/yfinkelstein/node-zookeeper/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/yfinkelstein/node-zookeeper/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly (if applicable).
