### PR TITLE
fix: build error in Node.js 22 caused by removed V8 AccessControl property

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "zookeeper",
     "description": "apache zookeeper client (zookeeper async API v3.5.x - v3.8.x)",
-    "version": "6.1.1",
+    "version": "6.2.0",
     "author": "Yuri Finkelstein <yurif2003@yahoo.com>",
     "license": "MIT",
     "contributors": [

--- a/src/node-zk.cpp
+++ b/src/node-zk.cpp
@@ -147,11 +147,11 @@ public:
         Nan::SetPrototypeMethod(constructor_template,  "a_reconfig",  AReconfig);
 
         //what's the advantage of using constructor_template->PrototypeTemplate()->SetAccessor ?
-        Nan::SetAccessor(constructor_template->InstanceTemplate(), LOCAL_STRING("state"), StatePropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
-        Nan::SetAccessor(constructor_template->InstanceTemplate(), LOCAL_STRING("client_id"), ClientidPropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
-        Nan::SetAccessor(constructor_template->InstanceTemplate(), LOCAL_STRING("client_password"), ClientPasswordPropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
-        Nan::SetAccessor(constructor_template->InstanceTemplate(), LOCAL_STRING("timeout"), SessionTimeoutPropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
-        Nan::SetAccessor(constructor_template->InstanceTemplate(), LOCAL_STRING("is_unrecoverable"), IsUnrecoverablePropertyGetter, 0, Local<Value>(), PROHIBITS_OVERWRITING, ReadOnly);
+        Nan::SetAccessor(constructor_template->InstanceTemplate(), LOCAL_STRING("state"), StatePropertyGetter, 0, Local<Value>(), DEFAULT, ReadOnly);
+        Nan::SetAccessor(constructor_template->InstanceTemplate(), LOCAL_STRING("client_id"), ClientidPropertyGetter, 0, Local<Value>(), DEFAULT, ReadOnly);
+        Nan::SetAccessor(constructor_template->InstanceTemplate(), LOCAL_STRING("client_password"), ClientPasswordPropertyGetter, 0, Local<Value>(), DEFAULT, ReadOnly);
+        Nan::SetAccessor(constructor_template->InstanceTemplate(), LOCAL_STRING("timeout"), SessionTimeoutPropertyGetter, 0, Local<Value>(), DEFAULT, ReadOnly);
+        Nan::SetAccessor(constructor_template->InstanceTemplate(), LOCAL_STRING("is_unrecoverable"), IsUnrecoverablePropertyGetter, 0, Local<Value>(), DEFAULT, ReadOnly);
 
 
         Local<Function> constructor = constructor_template->GetFunction(Nan::GetCurrentContext()).ToLocalChecked();

--- a/tests/components/README.md
+++ b/tests/components/README.md
@@ -3,7 +3,7 @@
 Unit tests written in JavaScript, verifying functionality in C++ files that are included in the ZooKeeper wrapper `node-zk.cpp`.
 
 ## Run tests
-
-`npm run test-converters`
+`npm run build-components`
+`npm run test-components`
 
 The command will build C++ code to Native Node.js addons, to make it testable with JavaScript. The source files are included by C++ wrapper files with Addon features from the Nan library (the files are stored in the `wrappers` folder).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replacing a removed V8 AccessControl enum property to the `DEFAULT`.

Details about the enum here:
https://v8docs.nodesource.com/node-20.3/d2/dc3/namespacev8.html#a2e9a0288e6c2df2ecebc50944c3ff9fa

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixing #343 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ Unit tests, integration tests, component tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/yfinkelstein/node-zookeeper/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/yfinkelstein/node-zookeeper/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
