### PR TITLE
Accept both perm and perms in acl objects

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -22,9 +22,17 @@ function isFunction(data) {
     return typeof data === 'function';
 }
 
+function toCompatibleAcl(acl) {
+    return acl.map((item) => {
+        const { perms: perm, ...rest } = item;
+        return { perm, ...rest };
+    });
+}
+
 module.exports = {
     deprecationLog,
     findZkConstantByCode,
     isString,
     isFunction,
+    toCompatibleAcl,
 };

--- a/lib/typedeclarations.d.ts
+++ b/lib/typedeclarations.d.ts
@@ -627,6 +627,14 @@ declare module "index" {
  * ACL object
  */
 type aclObject = {
+    perms: number;
+    scheme: string;
+    auth: string;
+};
+/**
+ * ACL object with perm
+ */
+type aclObject2 = {
     perm: number;
     scheme: string;
     auth: string;
@@ -634,7 +642,7 @@ type aclObject = {
 /**
  * ACL
  */
-type acl = Array<aclObject>;
+type acl = Array<aclObject | aclObject2>;
 /**
  * stat
  */

--- a/lib/typedefs.js
+++ b/lib/typedefs.js
@@ -1,6 +1,14 @@
 /**
  * ACL object
  * @typedef {Object} aclObject
+ * @property {number} perms
+ * @property {string} scheme
+ * @property {string} auth
+ */
+
+/**
+ * ACL object
+ * @typedef {Object} aclObject2
  * @property {number} perm
  * @property {string} scheme
  * @property {string} auth
@@ -8,7 +16,7 @@
 
 /**
  * ACL
- * @typedef {Array.<aclObject>} acl
+ * @typedef {Array.<aclObject | aclObject2>} acl
  */
 
 /**

--- a/lib/zk_promise.js
+++ b/lib/zk_promise.js
@@ -3,7 +3,7 @@
 const ZkPromise = require('./promise');
 const ZooKeeper = require('./zookeeper');
 const zkConstants = require('./constants');
-const { findZkConstantByCode } = require('./helper');
+const { findZkConstantByCode, toCompatibleAcl } = require('./helper');
 
 function isTruthy(data) {
     if (data) {

--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -5,7 +5,7 @@ const { EventEmitter } = require('events');
 const { join, posix } = require('path');
 const { apply, waterfall } = require('async');
 const NativeZk = require('node-gyp-build')(join(__dirname, '..')).ZooKeeper;
-const { isString, isFunction } = require('./helper');
+const { isString, isFunction, toCompatibleAcl } = require('./helper');
 
 const Async = {
     apply,
@@ -333,8 +333,9 @@ class ZooKeeper extends EventEmitter {
      * @returns {*}
      */
     a_set_acl(path, version, acl, voidCb) {
-        this.log(`Calling a_set_acl with ${util.inspect([path, version, acl, voidCb])}`);
-        return this.native.a_set_acl(path, version, acl, voidCb);
+        const compatibleAcl = toCompatibleAcl(acl);
+        this.log(`Calling a_set_acl with ${util.inspect([path, version, compatibleAcl, voidCb])}`);
+        return this.native.a_set_acl(path, version, compatibleAcl, voidCb);
     }
 
     /**

--- a/src/node-zk.cpp
+++ b/src/node-zk.cpp
@@ -999,7 +999,9 @@ public:
 
             Nan::Utf8String _scheme (toString(toLocalVal(obj, LOCAL_STRING("scheme"))));
             Nan::Utf8String _auth (toString(toLocalVal(obj, LOCAL_STRING("auth"))));
-            uint32_t _perms = toUint(toLocalVal(obj, LOCAL_STRING("perm")));
+            // check if perm or perms exists, later can be changed to accept just 'perms' on next major release
+            bool _hasPerm = Nan::HasOwnProperty(obj, LOCAL_STRING("perm")).FromMaybe(false);
+            uint32_t _perms = toUint(toLocalVal(obj, _hasPerm ? LOCAL_STRING("perm") : LOCAL_STRING("perms")));
 
             struct Id id;
             struct ACL *acl = &aclv->data[i];

--- a/src/node-zk.cpp
+++ b/src/node-zk.cpp
@@ -999,9 +999,7 @@ public:
 
             Nan::Utf8String _scheme (toString(toLocalVal(obj, LOCAL_STRING("scheme"))));
             Nan::Utf8String _auth (toString(toLocalVal(obj, LOCAL_STRING("auth"))));
-            // check if perm or perms exists, later can be changed to accept just 'perms' on next major release
-            bool _hasPerm = Nan::HasOwnProperty(obj, LOCAL_STRING("perm")).FromMaybe(false);
-            uint32_t _perms = toUint(toLocalVal(obj, _hasPerm ? LOCAL_STRING("perm") : LOCAL_STRING("perms")));
+            uint32_t _perms = toUint(toLocalVal(obj, LOCAL_STRING("perm")));
 
             struct Id id;
             struct ACL *acl = &aclv->data[i];

--- a/tests/integration/getAndSetAcltest.js
+++ b/tests/integration/getAndSetAcltest.js
@@ -1,0 +1,64 @@
+const test = require('ava');
+const { constants, createClient } = require('./helpers/createClient');
+
+test('can get and set acl of the node using perm', async (t) => {
+    const client = createClient();
+
+    await new Promise((resolve) => {
+        client.on('connect', async () => {
+            const path = '/acl-testing';
+            const data = '';
+            const flags = constants.ZOO_EPHEMERAL;
+            const version = 0;
+
+            await client.create(path, data, flags);
+
+            const updatedAcl = [{
+                perm: constants.ZOO_PERM_READ,
+                scheme: 'world',
+                auth: 'anyone',
+            }];
+
+            await client.set_acl(path, version, updatedAcl);
+            const [after] = await client.get_acl(path);
+
+            t.is(after[0].perms, 1);
+
+            client.close();
+        });
+
+        client.on('close', () => resolve());
+        client.init({});
+    });
+});
+
+test('can get and set acl of the node using perms', async (t) => {
+    const client = createClient();
+
+    await new Promise((resolve) => {
+        client.on('connect', async () => {
+            const path = '/acl-testing2';
+            const data = '';
+            const flags = constants.ZOO_EPHEMERAL;
+            const version = 0;
+
+            await client.create(path, data, flags);
+
+            const updatedAcl = [{
+                perms: constants.ZOO_PERM_READ,
+                scheme: 'world',
+                auth: 'anyone',
+            }];
+
+            await client.set_acl(path, version, updatedAcl);
+            const [after] = await client.get_acl(path);
+
+            t.is(after[0].perms, 1);
+
+            client.close();
+        });
+
+        client.on('close', () => resolve());
+        client.init({});
+    });
+});

--- a/tests/unit/util/helpertest.js
+++ b/tests/unit/util/helpertest.js
@@ -6,6 +6,7 @@ const {
     findZkConstantByCode,
     isString,
     isFunction,
+    toCompatibleAcl,
 } = require('../../../lib/helper');
 
 class Test {
@@ -67,4 +68,28 @@ test('identifies data as functions', (t) => {
 
     t.false(isFunction('data'));
     t.false(isFunction(null));
+});
+
+test('converts an ACL object to an AddOn compatible object', (t) => {
+    const original = [{ perms: 1, scheme: 'world', auth: 'anyone' }];
+    const expected = [{ perm: 1, scheme: 'world', auth: 'anyone' }];
+
+    t.deepEqual(toCompatibleAcl(original), expected);
+});
+
+test('leaves an existing ACL object unchanged', (t) => {
+    const original = [{ perm: 1, scheme: 'world', auth: 'anyone' }];
+
+    t.deepEqual(toCompatibleAcl(original), original);
+});
+
+test('overrides the ACL perm key when both are added', (t) => {
+    const original = [{
+        perm: 1, perms: 9, scheme: 'world', auth: 'anyone',
+    }];
+    const expected = [{
+        perm: 1, scheme: 'world', auth: 'anyone',
+    }];
+
+    t.deepEqual(toCompatibleAcl(original), expected);
 });


### PR DESCRIPTION
Accept both perm and perms while creating an acl object

## Description
Accept both perm and perms in acl objects while setting acl for a zookeeper node

## Motivation and Context
get_acl returns acl objects with **perms** key, while set_acl accepts only **perm** key, these need to be consistent, so updated the code to take both, so there is no any breaking change and it's consistent.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Added an integration test: [tests/integration/getAndSetAcltest.js](tests/integration/getAndSetAcltest.js)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/yfinkelstein/node-zookeeper/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/yfinkelstein/node-zookeeper/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
