### PR TITLE
Add disconnected state event

### DIFF
--- a/src/node-zk.cpp
+++ b/src/node-zk.cpp
@@ -1169,7 +1169,7 @@ extern "C" void init(Local<Object> target) {
     INITIALIZE_STRING (zk::on_closed,            "close");
     INITIALIZE_STRING (zk::on_connected,         "connect");
     INITIALIZE_STRING (zk::on_disconnected,      "disconnect");
-    INITIALIZE_STRING (zk::on_disconnected_cleared,"disconnect_cleared");
+    INITIALIZE_STRING (zk::on_disconnected_cleared, "disconnect_cleared");
     INITIALIZE_STRING (zk::on_connecting,        "connecting");
     INITIALIZE_STRING (zk::on_event_created,     "created");
     INITIALIZE_STRING (zk::on_event_deleted,     "deleted");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
add a disconnected state event

## Motivation and Context
1. To solve ISSUE #351 (can't report network error event);
2. Support for listening to network error events.

## How Has This Been Tested?
Test Action
1. Run `node examples/index.js`
2. Turned off Client NetWork
4. Turned NetWork back on

Result
1.  Everything is working normally.
2. The disconnected and disconnected_cleared events were reported, and other events were reported normally.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have read the [code of conduct](https://github.com/yfinkelstein/node-zookeeper/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/yfinkelstein/node-zookeeper/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
