### PR TITLE
feat(beta): enable workers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "zookeeper",
     "description": "apache zookeeper client (zookeeper async API v3.5.x - v3.8.x)",
-    "version": "6.2.3",
+    "version": "7.0.0-beta.0",
     "author": "Yuri Finkelstein <yurif2003@yahoo.com>",
     "license": "MIT",
     "contributors": [

--- a/src/node-zk.cpp
+++ b/src/node-zk.cpp
@@ -1165,4 +1165,4 @@ extern "C" void init(Local<Object> target) {
     zk::ZooKeeper::Initialize(target);
 }
 
-NODE_MODULE(zookeeper, init)
+NAN_MODULE_WORKER_ENABLED(zookeeper, init)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Enable Workers, by using the Nan worker replacement for. `NODE_MODULE`.

**NOTE:** this is a beta release. Use with Node.js v22 to force the building of the add-on when running `npm install` (v20 has prebuilds already for Mac OS X and Windows, and this change is not in the prebuilds yet).

The soulution was found here:
https://github.com/nktnet1/easy-libcurl/pull/66
https://github.com/nodejs/nan/issues/844

and

https://github.com/nodejs/nan/blob/9585023a32bf0e945c932200fc7f1ddbcf1fadad/CHANGELOG.md?plain=1#L88C14-L88C85


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Adresses the issues raised in #314 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ local build and run `node examples/index.js`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/yfinkelstein/node-zookeeper/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/yfinkelstein/node-zookeeper/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
